### PR TITLE
Branch 2.3

### DIFF
--- a/src/spooq2/transformer/mapper_custom_data_types.py
+++ b/src/spooq2/transformer/mapper_custom_data_types.py
@@ -787,9 +787,14 @@ def _generate_select_expression_for_extended_string_to_timestamp(source_column, 
     """
     More robust conversion from StringType to TimestampType. It is assumed that the
     timezone is already set to UTC in spark / java to avoid implicit timezone conversions.
+    The conversion can handle unix timestamps in seconds and in milliseconds:
+        - Timestamps in the range [-MAX_TIMESTAMP_S, MAX_TIMESTAMP_S] are treated as seconds
+        - Timestamps in the range [-inf, -MAX_TIMESTAMP_S) and (MAX_TIMESTAMP_S, inf] are treated as milliseconds
+        - There is a time interval (1970-01-01 +- ~2.5 months)where we can not distinguish correctly between s and ms
+          (e.g. 3974400000 would be treated as seconds (2095-12-11T00:00:00) as the value is smaller than
+          MAX_TIMESTAMP_S, but it could also be a valid date in Milliseconds (1970-02-16T00:00:00)
     Is able to additionally handle (compared to implicit Spark conversion):
 
-    * Unix timestamps in seconds
     * Preceding whitespace
     * Trailing whitespace
     * Preceeding and trailing whitespace
@@ -817,8 +822,11 @@ def _generate_select_expression_for_extended_string_to_timestamp(source_column, 
     """
     return (
         F.when(
-            F.trim(source_column).cast(T.LongType()).isNotNull(),
+            F.abs(F.trim(source_column).cast(T.LongType())).between(0, MAX_TIMESTAMP_SEC),
             F.trim(source_column).cast(T.LongType()).cast(T.TimestampType())
+        ).when(
+            F.abs(F.trim(source_column).cast(T.LongType())) > MAX_TIMESTAMP_SEC,
+            (F.trim(source_column) / 1000).cast(T.LongType()).cast(T.TimestampType())
         ).otherwise(F.trim(source_column).cast(T.TimestampType())).alias(name)
     )
 

--- a/src/spooq2/transformer/mapper_custom_data_types.py
+++ b/src/spooq2/transformer/mapper_custom_data_types.py
@@ -793,8 +793,8 @@ def _generate_select_expression_for_extended_string_to_timestamp(source_column, 
         - There is a time interval (1970-01-01 +- ~2.5 months)where we can not distinguish correctly between s and ms
           (e.g. 3974400000 would be treated as seconds (2095-12-11T00:00:00) as the value is smaller than
           MAX_TIMESTAMP_S, but it could also be a valid date in Milliseconds (1970-02-16T00:00:00)
-    Is able to additionally handle (compared to implicit Spark conversion):
 
+    Is able to additionally handle (compared to implicit Spark conversion):
     * Preceding whitespace
     * Trailing whitespace
     * Preceeding and trailing whitespace
@@ -834,8 +834,18 @@ def _generate_select_expression_for_extended_string_to_timestamp(source_column, 
 def _generate_select_expression_for_extended_string_to_date(source_column, name):
     """
     More robust conversion from StringType to DateType. It is assumed that the
-    timezone is already set to UTC in spark / java to avoid implicit timezone conversions and that
-    unix timestamps are in **seconds**
+    timezone is already set to UTC in spark / java to avoid implicit timezone conversions.
+    The conversion can handle unix timestamps in seconds and in milliseconds:
+        - Timestamps in the range [-MAX_TIMESTAMP_S, MAX_TIMESTAMP_S] are treated as seconds
+        - Timestamps in the range [-inf, -MAX_TIMESTAMP_S) and (MAX_TIMESTAMP_S, inf] are treated as milliseconds
+        - There is a time interval (1970-01-01 +- ~2.5 months)where we can not distinguish correctly between s and ms
+          (e.g. 3974400000 would be treated as seconds (2095-12-11T00:00:00) as the value is smaller than
+          MAX_TIMESTAMP_S, but it could also be a valid date in Milliseconds (1970-02-16T00:00:00)
+
+    Is able to additionally handle (compared to implicit Spark conversion):
+    * Preceding whitespace
+    * Trailing whitespace
+    * Preceeding and trailing whitespace
 
     Hint
     ----

--- a/tests/data/test_fixtures/mapper_custom_data_types_fixtures.py
+++ b/tests/data/test_fixtures/mapper_custom_data_types_fixtures.py
@@ -241,8 +241,10 @@ fixtures_for_extended_string_to_timestamp = [
     (1597069446,                   datetime.datetime(2020, 8, 10, 14, 24, 6)),
     ("-1597069446",                datetime.datetime(1919, 5, 24, 9, 35, 54)),
     (-1597069446,                  datetime.datetime(1919, 5, 24, 9, 35, 54)),
-    ("1597069446000",              "out_of_range_for_python"),  # Spark can handle it but not Python
-    ("-1597069446000",             "out_of_range_for_python"),  # Spark can handle it but not Python
+    ("1597069446000",              datetime.datetime(2020, 8, 10, 14, 24, 6)),
+    (1597069446000,                datetime.datetime(2020, 8, 10, 14, 24, 6)),
+    ("-1597069446000",             datetime.datetime(1919, 5, 24, 9, 35, 54)),
+    (-1597069446000,               datetime.datetime(1919, 5, 24, 9, 35, 54)),
     ("null",                       None),
     ("0",                          datetime.datetime(1970, 1, 1, 0, 0, 0)),
     ("-1",                         datetime.datetime(1969, 12, 31, 23, 59, 59)),

--- a/tests/data/test_fixtures/mapper_custom_data_types_fixtures.py
+++ b/tests/data/test_fixtures/mapper_custom_data_types_fixtures.py
@@ -297,8 +297,8 @@ fixtures_for_extended_string_to_date = [
     (1597069446,                   datetime.date(2020, 8, 10)),
     ("-1597069446",                datetime.date(1919, 5, 24)),
     (-1597069446,                  datetime.date(1919, 5, 24)),
-    ("1597069446000",              "out_of_range_for_python"),  # Spark can handle it but not Python
-    ("-1597069446000",             "out_of_range_for_python"),  # Spark can handle it but not Python
+    ("1597069446000",              datetime.date(2020, 8, 10)),
+    ("-1597069446000",             datetime.date(1919, 5, 24)),
     ("null",                       None),
     ("0",                          datetime.date(1970, 1, 1,)),
     ("-1",                         datetime.date(1969, 12, 31,)),


### PR DESCRIPTION
Updated select expression for `extended_string_to_timestamp` mapper function to handle both, unix timestamps in seconds and in milliseconds. Changes are unit tested and documented inside the function docstring.