### PR TITLE
Spooq mapping has capability to add comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,19 @@ for_thesis/yelp_data_set/
 
 # Sphinx Build
 docs/build/html/
+
+archive/
+build/
+for_thesis/
+output.json
+pytest_html_report.html
+temp/
+out/
+tests.html
+tests/all_tests.html
+tests/archive/
+tests/output.json
+tests/pytest_html_report.html
+tests/tests.html
+tests/unit/archive/
+tests/unit/output.json

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+3.4.2 (2024-07-17)
+-------------------
+* [ADD] Annotator: New transformer to load and apply comments to dataframes
+* [MOD] Mapper: Change mode and missing_column_handling from strings to Enums
+
 3.4.1 (2024-06-05)
 -------------------
 * [MOD] Mapper: Add validation mode
@@ -22,8 +27,7 @@ Changelog
 
 3.3.9 (2022-08-16)
 ------------------
-* [MOD] Mapper: Replace missing column parameters (`nullify_missing_columns`, `skip_missing_columns`,
-`ignore_missing_columns`) with one single parameter: `missing_column_handling`
+* [MOD] Mapper: Replace missing column parameters (`nullify_missing_columns`, `skip_missing_columns`, `ignore_missing_columns`) with one single parameter: `missing_column_handling`.
 
 3.3.8 (2022-08-11)
 -------------------

--- a/Pipfile
+++ b/Pipfile
@@ -41,6 +41,7 @@ twine = "*"
 pytest-html-reporter = "*"
 semver = "*"
 build = "*"
+black = "*"
 
 [packages]
 pandas = "<2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a31e4ab75a85c2b652b1d956b2c183fa51808bb2e0e25a5dbd27bba8d4ec92d0"
+            "sha256": "061f71291083bcd7c675ee917d03d48aa1112be21e747dea28968a9c7c6ddc58"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
-                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.2.2"
+            "version": "==2024.7.4"
         },
         "charset-normalizer": {
             "hashes": [
@@ -122,12 +122,12 @@
         },
         "delta-spark": {
             "hashes": [
-                "sha256:a35cc90b456f02ffad9c5960d6c961cea1526d98fb0928f6989305572696ff72",
-                "sha256:dca2d48d53de8061612a7b1860cd7dd5f9b3b4a1f29a06d1f19f047c4dc6afb9"
+                "sha256:7204142a97ef16367403b020d810d0c37f4ae8275b4997de4056423cf69b3a4b",
+                "sha256:ef776e325e80d98e3920cab982c747b094acc46599d62dfcdc9035fb112ba6a9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==3.1.0"
+            "version": "==2.4.0"
         },
         "future": {
             "hashes": [
@@ -135,24 +135,24 @@
                 "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.0.0"
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792",
-                "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"
+                "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f",
+                "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.0.2"
+            "version": "==8.0.0"
         },
         "numpy": {
             "hashes": [
@@ -190,35 +190,37 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:04dbdbaf2e4d46ca8da896e1805bc04eb85caa9a82e259e8eed00254d5e0c682",
-                "sha256:1168574b036cd8b93abc746171c9b4f1b83467438a5e45909fed645cf8692dbc",
-                "sha256:1994c789bf12a7c5098277fb43836ce090f1073858c10f9220998ac74f37c69b",
-                "sha256:258d3624b3ae734490e4d63c430256e716f488c4fcb7c8e9bde2d3aa46c29089",
-                "sha256:32fca2ee1b0d93dd71d979726b12b61faa06aeb93cf77468776287f41ff8fdc5",
-                "sha256:37673e3bdf1551b95bf5d4ce372b37770f9529743d2498032439371fc7b7eb26",
-                "sha256:3ef285093b4fe5058eefd756100a367f27029913760773c8bf1d2d8bebe5d210",
-                "sha256:5247fb1ba347c1261cbbf0fcfba4a3121fbb4029d95d9ef4dc45406620b25c8b",
-                "sha256:5ec591c48e29226bcbb316e0c1e9423622bc7a4eaf1ef7c3c9fa1a3981f89641",
-                "sha256:694888a81198786f0e164ee3a581df7d505024fbb1f15202fc7db88a71d84ebd",
-                "sha256:69d7f3884c95da3a31ef82b7618af5710dba95bb885ffab339aad925c3e8ce78",
-                "sha256:6a21ab5c89dcbd57f78d0ae16630b090eec626360085a4148693def5452d8a6b",
-                "sha256:81af086f4543c9d8bb128328b5d32e9986e0c84d3ee673a2ac6fb57fd14f755e",
-                "sha256:9e4da0d45e7f34c069fe4d522359df7d23badf83abc1d1cef398895822d11061",
-                "sha256:9eae3dc34fa1aa7772dd3fc60270d13ced7346fcbcfee017d3132ec625e23bb0",
-                "sha256:9ee1a69328d5c36c98d8e74db06f4ad518a1840e8ccb94a4ba86920986bb617e",
-                "sha256:b084b91d8d66ab19f5bb3256cbd5ea661848338301940e17f4492b2ce0801fe8",
-                "sha256:b9cb1e14fdb546396b7e1b923ffaeeac24e4cedd14266c3497216dd4448e4f2d",
-                "sha256:ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0",
-                "sha256:c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c",
-                "sha256:ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183",
-                "sha256:d9cd88488cceb7635aebb84809d087468eb33551097d600c6dad13602029c2df",
-                "sha256:e4c7c9f27a4185304c7caf96dc7d91bc60bc162221152de697c98eb0b2648dd8",
-                "sha256:f167beed68918d62bffb6ec64f2e1d8a7d297a038f86d4aed056b9493fca407f",
-                "sha256:f3421a7afb1a43f7e38e82e844e2bca9a6d793d66c1a7f9f0ff39a795bbc5e02"
+                "sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813",
+                "sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792",
+                "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406",
+                "sha256:41179ce559943d83a9b4bbacb736b04c928b095b5f25dd2b7389eda08f46f373",
+                "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328",
+                "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996",
+                "sha256:565fa34a5434d38e9d250af3c12ff931abaf88050551d9fbcdfafca50d62babf",
+                "sha256:5f2b952406a1588ad4cad5b3f55f520e82e902388a6d5a4a91baa8d38d23c7f6",
+                "sha256:5fbcb19d6fceb9e946b3e23258757c7b225ba450990d9ed63ccceeb8cae609f7",
+                "sha256:6973549c01ca91ec96199e940495219c887ea815b2083722821f1d7abfa2b4dc",
+                "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1",
+                "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23",
+                "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a",
+                "sha256:87bd9c03da1ac870a6d2c8902a0e1fd4267ca00f13bc494c9e5a9020920e1d51",
+                "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572",
+                "sha256:9842b6f4b8479e41968eced654487258ed81df7d1c9b7b870ceea24ed9459b31",
+                "sha256:9f69c4029613de47816b1bb30ff5ac778686688751a5e9c99ad8c7031f6508e5",
+                "sha256:a50d9a4336a9621cab7b8eb3fb11adb82de58f9b91d84c2cd526576b881a0c5a",
+                "sha256:bc4c368f42b551bf72fac35c5128963a171b40dce866fb066540eeaf46faa003",
+                "sha256:c39a8da13cede5adcd3be1182883aea1c925476f4e84b2807a46e2775306305d",
+                "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354",
+                "sha256:c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee",
+                "sha256:c74a62747864ed568f5a82a49a23a8d7fe171d0c69038b38cedf0976831296fa",
+                "sha256:dd05f7783b3274aa206a1af06f0ceed3f9b412cf665b7247eacd83be41cf7bf0",
+                "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9",
+                "sha256:e474390e60ed609cec869b0da796ad94f420bb057d86784191eefc62b65819ae",
+                "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.0.3"
+            "version": "==1.5.3"
         },
         "py4j": {
             "hashes": [
@@ -229,18 +231,18 @@
         },
         "pyspark": {
             "hashes": [
-                "sha256:dd6569e547365eadc4f887bf57f153e4d582a68c4b490de475d55b9981664910"
+                "sha256:088db1b8ff33a748b802f1710ff6f6dcef0e0f2cca7d69bbbe55b187a0d55c3f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==3.5.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.2"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -252,48 +254,40 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "spooq": {
             "editable": true,
             "path": "."
         },
-        "tzdata": {
-            "hashes": [
-                "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
-                "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"
-            ],
-            "markers": "python_version >= '2'",
-            "version": "==2024.1"
-        },
         "urllib3": {
             "hashes": [
-                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "zipp": {
             "hashes": [
-                "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b",
-                "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
+                "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19",
+                "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.18.1"
+            "version": "==3.19.2"
         }
     },
     "develop": {
@@ -307,20 +301,20 @@
         },
         "ansi2html": {
             "hashes": [
-                "sha256:29ccdb1e83520d648ebdc9c9544059ea4d424ecc33d3ef723657f7f5a9ae5225",
-                "sha256:5c6837a13ecc1903aab7a545353312049dfedfe5105362ad3a8d9d207871ec71"
+                "sha256:3453bf87535d37b827b05245faaa756dbab4ec3d69925e352b6319c3c955c0a5",
+                "sha256:dccb75aa95fb018e5d299be2b45f802952377abfdce0504c17a6ee6ef0a420c5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==1.9.1"
+            "version": "==1.9.2"
         },
         "astroid": {
             "hashes": [
-                "sha256:951798f922990137ac090c53af473db7ab4e70c770e6d7fae0cec59f74411819",
-                "sha256:ac248253bfa4bd924a0de213707e7ebeeb3138abeb48d798784ead1e56d419d4"
+                "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94",
+                "sha256:e8a0083b4bb28fcffb6207a3bfc9e5d0a68be951dd7e336d5dcf639c682388c0"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.1.0"
+            "version": "==3.2.2"
         },
         "asttokens": {
             "hashes": [
@@ -331,11 +325,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363",
-                "sha256:efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287"
+                "sha256:08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb",
+                "sha256:8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.14.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.15.0"
         },
         "backcall": {
             "hashes": [
@@ -344,13 +338,59 @@
             ],
             "version": "==0.2.0"
         },
+        "backports.tarfile": {
+            "hashes": [
+                "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+                "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"
+            ],
+            "markers": "python_version < '3.12'",
+            "version": "==1.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474",
+                "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1",
+                "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0",
+                "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8",
+                "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96",
+                "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1",
+                "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04",
+                "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021",
+                "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94",
+                "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d",
+                "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c",
+                "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7",
+                "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c",
+                "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc",
+                "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7",
+                "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d",
+                "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c",
+                "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741",
+                "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce",
+                "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb",
+                "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063",
+                "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==24.4.2"
+        },
         "blinker": {
             "hashes": [
-                "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9",
-                "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182"
+                "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01",
+                "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.7.0"
+            "version": "==1.8.2"
+        },
+        "build": {
+            "hashes": [
+                "sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d",
+                "sha256:75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.2.1"
         },
         "bump2version": {
             "hashes": [
@@ -363,11 +403,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
-                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.2.2"
+            "version": "==2024.7.4"
         },
         "cffi": {
             "hashes": [
@@ -560,99 +600,99 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c",
-                "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63",
-                "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7",
-                "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f",
-                "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8",
-                "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf",
-                "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0",
-                "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384",
-                "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76",
-                "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7",
-                "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d",
-                "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70",
-                "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f",
-                "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818",
-                "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b",
-                "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d",
-                "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec",
-                "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083",
-                "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2",
-                "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9",
-                "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd",
-                "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade",
-                "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e",
-                "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a",
-                "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227",
-                "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87",
-                "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c",
-                "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e",
-                "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c",
-                "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e",
-                "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd",
-                "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec",
-                "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562",
-                "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8",
-                "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677",
-                "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357",
-                "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c",
-                "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd",
-                "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49",
-                "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286",
-                "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1",
-                "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf",
-                "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51",
-                "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409",
-                "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384",
-                "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e",
-                "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978",
-                "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57",
-                "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e",
-                "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2",
-                "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48",
-                "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"
+                "sha256:018a12985185038a5b2bcafab04ab833a9a0f2c59995b3cec07e10074c78635f",
+                "sha256:02ff6e898197cc1e9fa375581382b72498eb2e6d5fc0b53f03e496cfee3fac6d",
+                "sha256:042183de01f8b6d531e10c197f7f0315a61e8d805ab29c5f7b51a01d62782747",
+                "sha256:1014fbf665fef86cdfd6cb5b7371496ce35e4d2a00cda501cf9f5b9e6fced69f",
+                "sha256:1137f46adb28e3813dec8c01fefadcb8c614f33576f672962e323b5128d9a68d",
+                "sha256:16852febd96acd953b0d55fc842ce2dac1710f26729b31c80b940b9afcd9896f",
+                "sha256:2174e7c23e0a454ffe12267a10732c273243b4f2d50d07544a91198f05c48f47",
+                "sha256:2214ee920787d85db1b6a0bd9da5f8503ccc8fcd5814d90796c2f2493a2f4d2e",
+                "sha256:3257fdd8e574805f27bb5342b77bc65578e98cbc004a92232106344053f319ba",
+                "sha256:3684bc2ff328f935981847082ba4fdc950d58906a40eafa93510d1b54c08a66c",
+                "sha256:3a6612c99081d8d6134005b1354191e103ec9705d7ba2754e848211ac8cacc6b",
+                "sha256:3d7564cc09dd91b5a6001754a5b3c6ecc4aba6323baf33a12bd751036c998be4",
+                "sha256:44da56a2589b684813f86d07597fdf8a9c6ce77f58976727329272f5a01f99f7",
+                "sha256:5013ed890dc917cef2c9f765c4c6a8ae9df983cd60dbb635df8ed9f4ebc9f555",
+                "sha256:54317c2b806354cbb2dc7ac27e2b93f97096912cc16b18289c5d4e44fc663233",
+                "sha256:56b4eafa21c6c175b3ede004ca12c653a88b6f922494b023aeb1e836df953ace",
+                "sha256:581ea96f92bf71a5ec0974001f900db495488434a6928a2ca7f01eee20c23805",
+                "sha256:5cd64adedf3be66f8ccee418473c2916492d53cbafbfcff851cbec5a8454b136",
+                "sha256:5df54843b88901fdc2f598ac06737f03d71168fd1175728054c8f5a2739ac3e4",
+                "sha256:65e528e2e921ba8fd67d9055e6b9f9e34b21ebd6768ae1c1723f4ea6ace1234d",
+                "sha256:6aae5cce399a0f065da65c7bb1e8abd5c7a3043da9dceb429ebe1b289bc07806",
+                "sha256:6cfb5a4f556bb51aba274588200a46e4dd6b505fb1a5f8c5ae408222eb416f99",
+                "sha256:7076b4b3a5f6d2b5d7f1185fde25b1e54eb66e647a1dfef0e2c2bfaf9b4c88c8",
+                "sha256:73ca8fbc5bc622e54627314c1a6f1dfdd8db69788f3443e752c215f29fa87a0b",
+                "sha256:79b356f3dd5b26f3ad23b35c75dbdaf1f9e2450b6bcefc6d0825ea0aa3f86ca5",
+                "sha256:7a892be37ca35eb5019ec85402c3371b0f7cda5ab5056023a7f13da0961e60da",
+                "sha256:8192794d120167e2a64721d88dbd688584675e86e15d0569599257566dec9bf0",
+                "sha256:820bc841faa502e727a48311948e0461132a9c8baa42f6b2b84a29ced24cc078",
+                "sha256:8f894208794b164e6bd4bba61fc98bf6b06be4d390cf2daacfa6eca0a6d2bb4f",
+                "sha256:a04e990a2a41740b02d6182b498ee9796cf60eefe40cf859b016650147908029",
+                "sha256:a44963520b069e12789d0faea4e9fdb1e410cdc4aab89d94f7f55cbb7fef0353",
+                "sha256:a6bb74ed465d5fb204b2ec41d79bcd28afccf817de721e8a807d5141c3426638",
+                "sha256:ab73b35e8d109bffbda9a3e91c64e29fe26e03e49addf5b43d85fc426dde11f9",
+                "sha256:aea072a941b033813f5e4814541fc265a5c12ed9720daef11ca516aeacd3bd7f",
+                "sha256:b1ccf5e728ccf83acd313c89f07c22d70d6c375a9c6f339233dcf792094bcbf7",
+                "sha256:b385d49609f8e9efc885790a5a0e89f2e3ae042cdf12958b6034cc442de428d3",
+                "sha256:b3d45ff86efb129c599a3b287ae2e44c1e281ae0f9a9bad0edc202179bcc3a2e",
+                "sha256:b4a474f799456e0eb46d78ab07303286a84a3140e9700b9e154cfebc8f527016",
+                "sha256:b95c3a8cb0463ba9f77383d0fa8c9194cf91f64445a63fc26fb2327e1e1eb088",
+                "sha256:c5986ee7ea0795a4095ac4d113cbb3448601efca7f158ec7f7087a6c705304e4",
+                "sha256:cdd31315fc20868c194130de9ee6bfd99755cc9565edff98ecc12585b90be882",
+                "sha256:cef4649ec906ea7ea5e9e796e68b987f83fa9a718514fe147f538cfeda76d7a7",
+                "sha256:d05c16cf4b4c2fc880cb12ba4c9b526e9e5d5bb1d81313d4d732a5b9fe2b9d53",
+                "sha256:d2e344d6adc8ef81c5a233d3a57b3c7d5181f40e79e05e1c143da143ccb6377d",
+                "sha256:d45d3cbd94159c468b9b8c5a556e3f6b81a8d1af2a92b77320e887c3e7a5d080",
+                "sha256:db14f552ac38f10758ad14dd7b983dbab424e731588d300c7db25b6f89e335b5",
+                "sha256:dbc5958cb471e5a5af41b0ddaea96a37e74ed289535e8deca404811f6cb0bc3d",
+                "sha256:ddbd2f9713a79e8e7242d7c51f1929611e991d855f414ca9996c20e44a895f7c",
+                "sha256:e16f3d6b491c48c5ae726308e6ab1e18ee830b4cdd6913f2d7f77354b33f91c8",
+                "sha256:e2afe743289273209c992075a5a4913e8d007d569a406ffed0bd080ea02b0633",
+                "sha256:e564c2cf45d2f44a9da56f4e3a26b2236504a496eb4cb0ca7221cd4cc7a9aca9",
+                "sha256:ed550e7442f278af76d9d65af48069f1fb84c9f745ae249c1a183c1e9d1b025c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.4.4"
+            "version": "==7.5.4"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
-                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
-                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
-                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
-                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
-                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
-                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
-                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
-                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
-                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
-                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
-                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
-                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
-                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
-                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
-                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
-                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
-                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
-                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
-                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
-                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
-                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
-                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
-                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
-                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
-                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
-                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
-                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
-                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
-                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
-                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
-                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
+                "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad",
+                "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583",
+                "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b",
+                "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c",
+                "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1",
+                "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648",
+                "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949",
+                "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba",
+                "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c",
+                "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9",
+                "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d",
+                "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c",
+                "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e",
+                "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2",
+                "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d",
+                "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7",
+                "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70",
+                "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2",
+                "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7",
+                "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14",
+                "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe",
+                "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e",
+                "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71",
+                "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961",
+                "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7",
+                "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c",
+                "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28",
+                "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842",
+                "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902",
+                "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801",
+                "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a",
+                "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.5"
+            "version": "==42.0.8"
         },
         "decorator": {
             "hashes": [
@@ -693,11 +733,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
-                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
+                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "executing": {
             "hashes": [
@@ -709,19 +749,19 @@
         },
         "faker": {
             "hashes": [
-                "sha256:87d5e7730426e7b36817921679c4eaf3d810cedb8c81194f47adc3df2122ca18",
-                "sha256:dce4754921f9fa7e2003c26834093361b8f45072e0f46f172d6ca1234774ecd4"
+                "sha256:0f60978314973de02c00474c2ae899785a42b2cf4f41b7987e93c132a2b8a4a9",
+                "sha256:886ee28219be96949cd21ecc96c4c742ee1680e77f687b095202c8def1a08f06"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.2.0"
+            "version": "==26.0.0"
         },
         "flask": {
             "hashes": [
-                "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e",
-                "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d"
+                "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3",
+                "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "grip": {
             "hashes": [
@@ -740,11 +780,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "imagesize": {
             "hashes": [
@@ -756,19 +796,19 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792",
-                "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"
+                "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f",
+                "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.0.2"
+            "version": "==8.0.0"
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:166072a97e86917a9025876f34286f549b9caf1d10b35a1b372bffa1600c6569",
-                "sha256:783407aa1cd05550e3aa123e8f7cfaebee35ffa9cb0242919e2d1e4172222705"
+                "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c",
+                "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==6.3.0"
+            "version": "==6.4.0"
         },
         "iniconfig": {
             "hashes": [
@@ -797,19 +837,35 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
-                "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
         },
         "jaraco.classes": {
             "hashes": [
-                "sha256:86b534de565381f6b3c1c830d13f931d7be1a75f0081c57dff615578676e2206",
-                "sha256:cb28a5ebda8bc47d8c8015307d93163464f9f2b91ab4006e09ff0ce07e8bfb30"
+                "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+                "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.3.1"
+            "version": "==3.4.0"
+        },
+        "jaraco.context": {
+            "hashes": [
+                "sha256:3e16388f7da43d384a1a7cd3452e72e14732ac9fe459678773a3608a812bf266",
+                "sha256:c2f67165ce1f9be20f32f650f25d8edfc1646a8aeee48ae06fb35f90763576d2"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==5.3.0"
+        },
+        "jaraco.functools": {
+            "hashes": [
+                "sha256:3b24ccb921d6b593bdceb56ce14799204f473976e2a9d4b15b04d0f2c2326664",
+                "sha256:d33fa765374c0611b52f8b3a795f8900869aa88c84769d4d1746cd68fb28c3e8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.0.1"
         },
         "jedi": {
             "hashes": [
@@ -829,19 +885,19 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
-                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.3"
+            "version": "==3.1.4"
         },
         "keyring": {
             "hashes": [
-                "sha256:c3327b6ffafc0e8befbdb597cacdb4928ffe5c1212f7645f186e6d9957a898db",
-                "sha256:df38a4d7419a6a60fea5cef1e45a948a3e8430dd12ad88b0f423c5c143906218"
+                "sha256:2458681cdefc0dbc0b7eb6cf75d0b98e59f9ad9b2d4edd319d18f68bdca95e50",
+                "sha256:daaffd42dbda25ddafb1ad5fec4024e5bbcfe424597ca1ca452b299861e49f1b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.3.1"
+            "version": "==25.2.1"
         },
         "markdown": {
             "hashes": [
@@ -927,11 +983,11 @@
         },
         "matplotlib-inline": {
             "hashes": [
-                "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
-                "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"
+                "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90",
+                "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.1.6"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.1.7"
         },
         "mccabe": {
             "hashes": [
@@ -961,11 +1017,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
-                "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"
+                "sha256:e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463",
+                "sha256:ea6a02e24a9161e51faad17a8782b92a0df82c12c1c8886fec7f0c3fa1a1b320"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.2.0"
+            "version": "==10.3.0"
         },
         "munch": {
             "hashes": [
@@ -975,26 +1031,34 @@
             "markers": "python_version >= '3.6'",
             "version": "==4.0.0"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
         "nh3": {
             "hashes": [
-                "sha256:0d02d0ff79dfd8208ed25a39c12cbda092388fff7f1662466e27d97ad011b770",
-                "sha256:3277481293b868b2715907310c7be0f1b9d10491d5adf9fce11756a97e97eddf",
-                "sha256:3b803a5875e7234907f7d64777dfde2b93db992376f3d6d7af7f3bc347deb305",
-                "sha256:427fecbb1031db085eaac9931362adf4a796428ef0163070c484b5a768e71601",
-                "sha256:5f0d77272ce6d34db6c87b4f894f037d55183d9518f948bba236fe81e2bb4e28",
-                "sha256:60684857cfa8fdbb74daa867e5cad3f0c9789415aba660614fe16cd66cbb9ec7",
-                "sha256:6f42f99f0cf6312e470b6c09e04da31f9abaadcd3eb591d7d1a88ea931dca7f3",
-                "sha256:86e447a63ca0b16318deb62498db4f76fc60699ce0a1231262880b38b6cff911",
-                "sha256:8d595df02413aa38586c24811237e95937ef18304e108b7e92c890a06793e3bf",
-                "sha256:9c0d415f6b7f2338f93035bba5c0d8c1b464e538bfbb1d598acd47d7969284f0",
-                "sha256:a5167a6403d19c515217b6bcaaa9be420974a6ac30e0da9e84d4fc67a5d474c5",
-                "sha256:ac19c0d68cd42ecd7ead91a3a032fdfff23d29302dbb1311e641a130dfefba97",
-                "sha256:b1e97221cedaf15a54f5243f2c5894bb12ca951ae4ddfd02a9d4ea9df9e1a29d",
-                "sha256:bc2d086fb540d0fa52ce35afaded4ea526b8fc4d3339f783db55c95de40ef02e",
-                "sha256:d1e30ff2d8d58fb2a14961f7aac1bbb1c51f9bdd7da727be35c63826060b0bf3",
-                "sha256:f3b53ba93bb7725acab1e030bc2ecd012a817040fd7851b332f86e2f9bb98dc6"
+                "sha256:0316c25b76289cf23be6b66c77d3608a4fdf537b35426280032f432f14291b9a",
+                "sha256:1a814dd7bba1cb0aba5bcb9bebcc88fd801b63e21e2450ae6c52d3b3336bc911",
+                "sha256:1aa52a7def528297f256de0844e8dd680ee279e79583c76d6fa73a978186ddfb",
+                "sha256:22c26e20acbb253a5bdd33d432a326d18508a910e4dcf9a3316179860d53345a",
+                "sha256:40015514022af31975c0b3bca4014634fa13cb5dc4dbcbc00570acc781316dcc",
+                "sha256:40d0741a19c3d645e54efba71cb0d8c475b59135c1e3c580f879ad5514cbf028",
+                "sha256:551672fd71d06cd828e282abdb810d1be24e1abb7ae2543a8fa36a71c1006fe9",
+                "sha256:66f17d78826096291bd264f260213d2b3905e3c7fae6dfc5337d49429f1dc9f3",
+                "sha256:85cdbcca8ef10733bd31f931956f7fbb85145a4d11ab9e6742bbf44d88b7e351",
+                "sha256:a3f55fabe29164ba6026b5ad5c3151c314d136fd67415a17660b4aaddacf1b10",
+                "sha256:b4427ef0d2dfdec10b641ed0bdaf17957eb625b2ec0ea9329b3d28806c153d71",
+                "sha256:ba73a2f8d3a1b966e9cdba7b211779ad8a2561d2dba9674b8a19ed817923f65f",
+                "sha256:c21bac1a7245cbd88c0b0e4a420221b7bfa838a2814ee5bb924e9c2f10a1120b",
+                "sha256:c551eb2a3876e8ff2ac63dff1585236ed5dfec5ffd82216a7a174f7c5082a78a",
+                "sha256:c790769152308421283679a142dbdb3d1c46c79c823008ecea8e8141db1a2062",
+                "sha256:d7a25fd8c86657f5d9d576268e3b3767c5cd4f42867c9383618be8517f0f022a"
             ],
-            "version": "==0.2.15"
+            "version": "==0.2.17"
         },
         "numpy": {
             "hashes": [
@@ -1032,25 +1096,33 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
         },
         "parso": {
             "hashes": [
-                "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0",
-                "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"
+                "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18",
+                "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.8.3"
+            "version": "==0.8.4"
         },
         "path-and-address": {
             "hashes": [
                 "sha256:e96363d982b3a2de8531f4cd5f086b51d0248b58527227d43cf5014d045371b7"
             ],
             "version": "==2.0.1"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
         },
         "pexpect": {
             "hashes": [
@@ -1069,77 +1141,89 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:0304004f8067386b477d20a518b50f3fa658a28d44e4116970abfcd94fac34a8",
-                "sha256:0689b5a8c5288bc0504d9fcee48f61a6a586b9b98514d7d29b840143d6734f39",
-                "sha256:0eae2073305f451d8ecacb5474997c08569fb4eb4ac231ffa4ad7d342fdc25ac",
-                "sha256:0fb3e7fc88a14eacd303e90481ad983fd5b69c761e9e6ef94c983f91025da869",
-                "sha256:11fa2e5984b949b0dd6d7a94d967743d87c577ff0b83392f17cb3990d0d2fd6e",
-                "sha256:127cee571038f252a552760076407f9cff79761c3d436a12af6000cd182a9d04",
-                "sha256:154e939c5f0053a383de4fd3d3da48d9427a7e985f58af8e94d0b3c9fcfcf4f9",
-                "sha256:15587643b9e5eb26c48e49a7b33659790d28f190fc514a322d55da2fb5c2950e",
-                "sha256:170aeb00224ab3dc54230c797f8404507240dd868cf52066f66a41b33169bdbe",
-                "sha256:1b5e1b74d1bd1b78bc3477528919414874748dd363e6272efd5abf7654e68bef",
-                "sha256:1da3b2703afd040cf65ec97efea81cfba59cdbed9c11d8efc5ab09df9509fc56",
-                "sha256:1e23412b5c41e58cec602f1135c57dfcf15482013ce6e5f093a86db69646a5aa",
-                "sha256:2247178effb34a77c11c0e8ac355c7a741ceca0a732b27bf11e747bbc950722f",
-                "sha256:257d8788df5ca62c980314053197f4d46eefedf4e6175bc9412f14412ec4ea2f",
-                "sha256:3031709084b6e7852d00479fd1d310b07d0ba82765f973b543c8af5061cf990e",
-                "sha256:322209c642aabdd6207517e9739c704dc9f9db943015535783239022002f054a",
-                "sha256:322bdf3c9b556e9ffb18f93462e5f749d3444ce081290352c6070d014c93feb2",
-                "sha256:33870dc4653c5017bf4c8873e5488d8f8d5f8935e2f1fb9a2208c47cdd66efd2",
-                "sha256:35bb52c37f256f662abdfa49d2dfa6ce5d93281d323a9af377a120e89a9eafb5",
-                "sha256:3c31822339516fb3c82d03f30e22b1d038da87ef27b6a78c9549888f8ceda39a",
-                "sha256:3eedd52442c0a5ff4f887fab0c1c0bb164d8635b32c894bc1faf4c618dd89df2",
-                "sha256:3ff074fc97dd4e80543a3e91f69d58889baf2002b6be64347ea8cf5533188213",
-                "sha256:47c0995fc4e7f79b5cfcab1fc437ff2890b770440f7696a3ba065ee0fd496563",
-                "sha256:49d9ba1ed0ef3e061088cd1e7538a0759aab559e2e0a80a36f9fd9d8c0c21591",
-                "sha256:51f1a1bffc50e2e9492e87d8e09a17c5eea8409cda8d3f277eb6edc82813c17c",
-                "sha256:52a50aa3fb3acb9cf7213573ef55d31d6eca37f5709c69e6858fe3bc04a5c2a2",
-                "sha256:54f1852cd531aa981bc0965b7d609f5f6cc8ce8c41b1139f6ed6b3c54ab82bfb",
-                "sha256:609448742444d9290fd687940ac0b57fb35e6fd92bdb65386e08e99af60bf757",
-                "sha256:69ffdd6120a4737710a9eee73e1d2e37db89b620f702754b8f6e62594471dee0",
-                "sha256:6fad5ff2f13d69b7e74ce5b4ecd12cc0ec530fcee76356cac6742785ff71c452",
-                "sha256:7049e301399273a0136ff39b84c3678e314f2158f50f517bc50285fb5ec847ad",
-                "sha256:70c61d4c475835a19b3a5aa42492409878bbca7438554a1f89d20d58a7c75c01",
-                "sha256:716d30ed977be8b37d3ef185fecb9e5a1d62d110dfbdcd1e2a122ab46fddb03f",
-                "sha256:753cd8f2086b2b80180d9b3010dd4ed147efc167c90d3bf593fe2af21265e5a5",
-                "sha256:773efe0603db30c281521a7c0214cad7836c03b8ccff897beae9b47c0b657d61",
-                "sha256:7823bdd049099efa16e4246bdf15e5a13dbb18a51b68fa06d6c1d4d8b99a796e",
-                "sha256:7c8f97e8e7a9009bcacbe3766a36175056c12f9a44e6e6f2d5caad06dcfbf03b",
-                "sha256:823ef7a27cf86df6597fa0671066c1b596f69eba53efa3d1e1cb8b30f3533068",
-                "sha256:8373c6c251f7ef8bda6675dd6d2b3a0fcc31edf1201266b5cf608b62a37407f9",
-                "sha256:83b2021f2ade7d1ed556bc50a399127d7fb245e725aa0113ebd05cfe88aaf588",
-                "sha256:870ea1ada0899fd0b79643990809323b389d4d1d46c192f97342eeb6ee0b8483",
-                "sha256:8d12251f02d69d8310b046e82572ed486685c38f02176bd08baf216746eb947f",
-                "sha256:9c23f307202661071d94b5e384e1e1dc7dfb972a28a2310e4ee16103e66ddb67",
-                "sha256:9d189550615b4948f45252d7f005e53c2040cea1af5b60d6f79491a6e147eef7",
-                "sha256:a086c2af425c5f62a65e12fbf385f7c9fcb8f107d0849dba5839461a129cf311",
-                "sha256:a2b56ba36e05f973d450582fb015594aaa78834fefe8dfb8fcd79b93e64ba4c6",
-                "sha256:aebb6044806f2e16ecc07b2a2637ee1ef67a11840a66752751714a0d924adf72",
-                "sha256:b1b3020d90c2d8e1dae29cf3ce54f8094f7938460fb5ce8bc5c01450b01fbaf6",
-                "sha256:b4b6b1e20608493548b1f32bce8cca185bf0480983890403d3b8753e44077129",
-                "sha256:b6f491cdf80ae540738859d9766783e3b3c8e5bd37f5dfa0b76abdecc5081f13",
-                "sha256:b792a349405fbc0163190fde0dc7b3fef3c9268292586cf5645598b48e63dc67",
-                "sha256:b7c2286c23cd350b80d2fc9d424fc797575fb16f854b831d16fd47ceec078f2c",
-                "sha256:babf5acfede515f176833ed6028754cbcd0d206f7f614ea3447d67c33be12516",
-                "sha256:c365fd1703040de1ec284b176d6af5abe21b427cb3a5ff68e0759e1e313a5e7e",
-                "sha256:c4225f5220f46b2fde568c74fca27ae9771536c2e29d7c04f4fb62c83275ac4e",
-                "sha256:c570f24be1e468e3f0ce7ef56a89a60f0e05b30a3669a459e419c6eac2c35364",
-                "sha256:c6dafac9e0f2b3c78df97e79af707cdc5ef8e88208d686a4847bab8266870023",
-                "sha256:c8de2789052ed501dd829e9cae8d3dcce7acb4777ea4a479c14521c942d395b1",
-                "sha256:cb28c753fd5eb3dd859b4ee95de66cc62af91bcff5db5f2571d32a520baf1f04",
-                "sha256:cb4c38abeef13c61d6916f264d4845fab99d7b711be96c326b84df9e3e0ff62d",
-                "sha256:d1b35bcd6c5543b9cb547dee3150c93008f8dd0f1fef78fc0cd2b141c5baf58a",
-                "sha256:d8e6aeb9201e655354b3ad049cb77d19813ad4ece0df1249d3c793de3774f8c7",
-                "sha256:d8ecd059fdaf60c1963c58ceb8997b32e9dc1b911f5da5307aab614f1ce5c2fb",
-                "sha256:da2b52b37dad6d9ec64e653637a096905b258d2fc2b984c41ae7d08b938a67e4",
-                "sha256:e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e",
-                "sha256:edca80cbfb2b68d7b56930b84a0e45ae1694aeba0541f798e908a49d66b837f1",
-                "sha256:f379abd2f1e3dddb2b61bc67977a6b5a0a3f7485538bcc6f39ec76163891ee48",
-                "sha256:fe4c15f6c9285dc54ce6553a3ce908ed37c8f3825b5a51a15c91442bb955b868"
+                "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885",
+                "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea",
+                "sha256:06b2f7898047ae93fad74467ec3d28fe84f7831370e3c258afa533f81ef7f3df",
+                "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5",
+                "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c",
+                "sha256:0ae24a547e8b711ccaaf99c9ae3cd975470e1a30caa80a6aaee9a2f19c05701d",
+                "sha256:134ace6dc392116566980ee7436477d844520a26a4b1bd4053f6f47d096997fd",
+                "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06",
+                "sha256:1b5dea9831a90e9d0721ec417a80d4cbd7022093ac38a568db2dd78363b00908",
+                "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a",
+                "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be",
+                "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0",
+                "sha256:298478fe4f77a4408895605f3482b6cc6222c018b2ce565c2b6b9c354ac3229b",
+                "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80",
+                "sha256:2db98790afc70118bd0255c2eeb465e9767ecf1f3c25f9a1abb8ffc8cfd1fe0a",
+                "sha256:32cda9e3d601a52baccb2856b8ea1fc213c90b340c542dcef77140dfa3278a9e",
+                "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9",
+                "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696",
+                "sha256:43efea75eb06b95d1631cb784aa40156177bf9dd5b4b03ff38979e048258bc6b",
+                "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309",
+                "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e",
+                "sha256:5161eef006d335e46895297f642341111945e2c1c899eb406882a6c61a4357ab",
+                "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d",
+                "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060",
+                "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d",
+                "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d",
+                "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4",
+                "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3",
+                "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6",
+                "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb",
+                "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94",
+                "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b",
+                "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496",
+                "sha256:73664fe514b34c8f02452ffb73b7a92c6774e39a647087f83d67f010eb9a0cf0",
+                "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319",
+                "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b",
+                "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856",
+                "sha256:7970285ab628a3779aecc35823296a7869f889b8329c16ad5a71e4901a3dc4ef",
+                "sha256:7a8d4bade9952ea9a77d0c3e49cbd8b2890a399422258a77f357b9cc9be8d680",
+                "sha256:7c1ee6f42250df403c5f103cbd2768a28fe1a0ea1f0f03fe151c8741e1469c8b",
+                "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42",
+                "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e",
+                "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597",
+                "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a",
+                "sha256:87dd88ded2e6d74d31e1e0a99a726a6765cda32d00ba72dc37f0651f306daaa8",
+                "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3",
+                "sha256:8d4d5063501b6dd4024b8ac2f04962d661222d120381272deea52e3fc52d3736",
+                "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da",
+                "sha256:930044bb7679ab003b14023138b50181899da3f25de50e9dbee23b61b4de2126",
+                "sha256:950be4d8ba92aca4b2bb0741285a46bfae3ca699ef913ec8416c1b78eadd64cd",
+                "sha256:961a7293b2457b405967af9c77dcaa43cc1a8cd50d23c532e62d48ab6cdd56f5",
+                "sha256:9b885f89040bb8c4a1573566bbb2f44f5c505ef6e74cec7ab9068c900047f04b",
+                "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026",
+                "sha256:a02364621fe369e06200d4a16558e056fe2805d3468350df3aef21e00d26214b",
+                "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc",
+                "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46",
+                "sha256:b15e02e9bb4c21e39876698abf233c8c579127986f8207200bc8a8f6bb27acf2",
+                "sha256:b2724fdb354a868ddf9a880cb84d102da914e99119211ef7ecbdc613b8c96b3c",
+                "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe",
+                "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984",
+                "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a",
+                "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70",
+                "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca",
+                "sha256:c76e5786951e72ed3686e122d14c5d7012f16c8303a674d18cdcd6d89557fc5b",
+                "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91",
+                "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3",
+                "sha256:d7480af14364494365e89d6fddc510a13e5a2c3584cb19ef65415ca57252fb84",
+                "sha256:dbc6ae66518ab3c5847659e9988c3b60dc94ffb48ef9168656e0019a93dbf8a1",
+                "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5",
+                "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be",
+                "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f",
+                "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc",
+                "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9",
+                "sha256:e88d5e6ad0d026fba7bdab8c3f225a69f063f116462c49892b0149e21b6c0a0e",
+                "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141",
+                "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef",
+                "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22",
+                "sha256:f7baece4ce06bade126fb84b8af1c33439a76d8a6fd818970215e0560ca28c27",
+                "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e",
+                "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.2.0"
+            "version": "==10.4.0"
         },
         "pkginfo": {
             "hashes": [
@@ -1151,27 +1235,27 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
-                "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
+                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.0"
+            "version": "==4.2.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d",
-                "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"
+                "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10",
+                "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.0.43"
+            "version": "==3.0.47"
         },
         "ptyprocess": {
             "hashes": [
@@ -1197,78 +1281,79 @@
         },
         "pyarrow": {
             "hashes": [
-                "sha256:07e652daac6d8b05280cd2af31c0fb61a4490ec6a53dc01588014d9fa3fdbee9",
-                "sha256:1519e218a6941fc074e4501088d891afcb2adf77c236e03c34babcf3d6a0d1c7",
-                "sha256:1b6e237dd7a08482a8b8f3f6512d258d2460f182931832a8c6ef3953203d31e1",
-                "sha256:21d812548d39d490e0c6928a7c663f37b96bf764034123d4b4ab4530ecc757a9",
-                "sha256:28cafa86e1944761970d3b3fc0411b14ff9b5c2b73cd22aaf470d7a3976335f5",
-                "sha256:2c1c3fc16bc74e33bf8f1e5a212938ed8d88e902f372c4dac6b5bad328567d2f",
-                "sha256:309e6191be385f2e220586bfdb643f9bb21d7e1bc6dd0a6963dc538e347b2431",
-                "sha256:31dc30c7ec8958da3a3d9f31d6c3630429b2091ede0ecd0d989fd6bec129f0e4",
-                "sha256:3a99eac76ae14096c209850935057b9e8ce97a78397c5cde8724674774f34e5d",
-                "sha256:3f111a014fb8ac2297b43a74bf4495cc479a332908f7ee49cb7cbd50714cb0c1",
-                "sha256:47b1eda15d3aa3f49a07b1808648e1397e5dc6a80a30bf87faa8e2d02dad7ac3",
-                "sha256:4f87757f02735a6bb4ad2e1b98279ac45d53b748d5baf52401516413007c6999",
-                "sha256:5186048493395220550bca7b524420471aac2d77af831f584ce132680f55c3df",
-                "sha256:738f6b53ab1c2f66b2bde8a1d77e186aeaab702d849e0dfa1158c9e2c030add3",
-                "sha256:7543ea88a0ff72f8e6baaf9bfdbec2c62aeabdbede9e4a571c71cc3bc43b6302",
-                "sha256:7bd167536ee23192760b8c731d39b7cfd37914c27fd4582335ffd08450ff799d",
-                "sha256:7c08bb31eb2984ba5c3747d375bb522e7e536b8b25b149c9cb5e1c49b0ccb736",
-                "sha256:83bc586903dbeb4365cbc72b602f99f70b96c5882e5dfac5278813c7d624ca3c",
-                "sha256:862eac5e5f3b6477f7a92b2f27e560e1f4e5e9edfca9ea9da8a7478bb4abd5ce",
-                "sha256:8f0ea3a29cd5cb99bf14c1c4533eceaa00ea8fb580950fb5a89a5c771a994a4e",
-                "sha256:9ad931b996f51c2f978ed517b55cb3c6078272fb4ec579e3da5a8c14873b698d",
-                "sha256:a476fefe8bdd56122fb0d4881b785413e025858803cc1302d0d788d3522b374d",
-                "sha256:a6d1f7c15d7f68f08490d0cb34611497c74285b8a6bbeab4ef3fc20117310983",
-                "sha256:abad2e08652df153a72177ce20c897d083b0c4ebeec051239e2654ddf4d3c996",
-                "sha256:b4157f307c202cbbdac147d9b07447a281fa8e63494f7fc85081da351ec6ace9",
-                "sha256:b75e7da26f383787f80ad76143b44844ffa28648fcc7099a83df1538c078d2f2",
-                "sha256:bb902f780cfd624b2e8fd8501fadab17618fdb548532620ef3d91312aaf0888a",
-                "sha256:be5c3d463e33d03eab496e1af7916b1d44001c08f0f458ad27dc16093a020638",
-                "sha256:c0f9c1d630ed2524bd1ddf28ec92780a7b599fd54704cd653519f7ff5aec177a",
-                "sha256:c2ddb3be5ea938c329a84171694fc230b241ce1b6b0ff1a0280509af51c375fa",
-                "sha256:cde663352bc83ad75ba7b3206e049ca1a69809223942362a8649e37bd22f9e3b",
-                "sha256:ce8c89848fd37e5313fc2ce601483038ee5566db96ba0808d5883b2e2e55dc53",
-                "sha256:dd532d3177e031e9b2d2df19fd003d0cc0520d1747659fcabbd4d9bb87de508c",
-                "sha256:e1fa92512128f6c1b8dde0468c1454dd70f3bff623970e370d52efd4d24fd0be",
-                "sha256:e524a31be7db22deebbbcf242b189063ab9a7652c62471d296b31bc6e3cae77b",
-                "sha256:efd3816c7fbfcbd406ac0f69873cebb052effd7cdc153ae5836d1b00845845d7"
+                "sha256:06ebccb6f8cb7357de85f60d5da50e83507954af617d7b05f48af1621d331c9a",
+                "sha256:0d07de3ee730647a600037bc1d7b7994067ed64d0eba797ac74b2bc77384f4c2",
+                "sha256:0d27bf89dfc2576f6206e9cd6cf7a107c9c06dc13d53bbc25b0bd4556f19cf5f",
+                "sha256:0d32000693deff8dc5df444b032b5985a48592c0697cb6e3071a5d59888714e2",
+                "sha256:15fbb22ea96d11f0b5768504a3f961edab25eaf4197c341720c4a387f6c60315",
+                "sha256:17e23b9a65a70cc733d8b738baa6ad3722298fa0c81d88f63ff94bf25eaa77b9",
+                "sha256:185d121b50836379fe012753cf15c4ba9638bda9645183ab36246923875f8d1b",
+                "sha256:18da9b76a36a954665ccca8aa6bd9f46c1145f79c0bb8f4f244f5f8e799bca55",
+                "sha256:19741c4dbbbc986d38856ee7ddfdd6a00fc3b0fc2d928795b95410d38bb97d15",
+                "sha256:25233642583bf658f629eb230b9bb79d9af4d9f9229890b3c878699c82f7d11e",
+                "sha256:2e51ca1d6ed7f2e9d5c3c83decf27b0d17bb207a7dea986e8dc3e24f80ff7d6f",
+                "sha256:2e73cfc4a99e796727919c5541c65bb88b973377501e39b9842ea71401ca6c1c",
+                "sha256:31a1851751433d89a986616015841977e0a188662fcffd1a5677453f1df2de0a",
+                "sha256:3b20bd67c94b3a2ea0a749d2a5712fc845a69cb5d52e78e6449bbd295611f3aa",
+                "sha256:4740cc41e2ba5d641071d0ab5e9ef9b5e6e8c7611351a5cb7c1d175eaf43674a",
+                "sha256:48be160782c0556156d91adbdd5a4a7e719f8d407cb46ae3bb4eaee09b3111bd",
+                "sha256:8785bb10d5d6fd5e15d718ee1d1f914fe768bf8b4d1e5e9bf253de8a26cb1628",
+                "sha256:98100e0268d04e0eec47b73f20b39c45b4006f3c4233719c3848aa27a03c1aef",
+                "sha256:99f7549779b6e434467d2aa43ab2b7224dd9e41bdde486020bae198978c9e05e",
+                "sha256:9cf389d444b0f41d9fe1444b70650fea31e9d52cfcb5f818b7888b91b586efff",
+                "sha256:a33a64576fddfbec0a44112eaf844c20853647ca833e9a647bfae0582b2ff94b",
+                "sha256:a8914cd176f448e09746037b0c6b3a9d7688cef451ec5735094055116857580c",
+                "sha256:b04707f1979815f5e49824ce52d1dceb46e2f12909a48a6a753fe7cafbc44a0c",
+                "sha256:b5f5705ab977947a43ac83b52ade3b881eb6e95fcc02d76f501d549a210ba77f",
+                "sha256:ba8ac20693c0bb0bf4b238751d4409e62852004a8cf031c73b0e0962b03e45e3",
+                "sha256:bf9251264247ecfe93e5f5a0cd43b8ae834f1e61d1abca22da55b20c788417f6",
+                "sha256:d0ebea336b535b37eee9eee31761813086d33ed06de9ab6fc6aaa0bace7b250c",
+                "sha256:ddf5aace92d520d3d2a20031d8b0ec27b4395cab9f74e07cc95edf42a5cc0147",
+                "sha256:ddfe389a08ea374972bd4065d5f25d14e36b43ebc22fc75f7b951f24378bf0b5",
+                "sha256:e1369af39587b794873b8a307cc6623a3b1194e69399af0efd05bb202195a5a7",
+                "sha256:e6b6d3cd35fbb93b70ade1336022cc1147b95ec6af7d36906ca7fe432eb09710",
+                "sha256:f07fdffe4fd5b15f5ec15c8b64584868d063bc22b86b46c9695624ca3505b7b4",
+                "sha256:f2c5fb249caa17b94e2b9278b36a05ce03d3180e6da0c4c3b3ce5b2788f30eed",
+                "sha256:f68f409e7b283c085f2da014f9ef81e885d90dcd733bd648cfba3ef265961848",
+                "sha256:fbef391b63f708e103df99fbaa3acf9f671d77a183a07546ba2f2c297b361e83",
+                "sha256:febde33305f1498f6df85e8020bca496d0e9ebf2093bab9e0f65e2b4ae2b3444"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==15.0.1"
+            "version": "==16.1.0"
         },
         "pycparser": {
             "hashes": [
-                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+                "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+                "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"
             ],
-            "version": "==2.21"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.22"
         },
         "pydash": {
             "hashes": [
-                "sha256:c3c5b54eec0a562e0080d6f82a14ad4d5090229847b7e554235b5c1558c745e1",
-                "sha256:cc935d5ac72dd41fb4515bdf982e7c864c8b5eeea16caffbab1936b849aaa49a"
+                "sha256:60265bab97fd00d5afd27dfbff9b6abfa22d0a965e166476b9066d84cd44c940",
+                "sha256:a24619643d3c054bfd56a9ae1cb7bd00e9774eaf369d7bb8d62b3daa2462bdbd"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.0.7"
+            "version": "==8.0.1"
         },
         "pygments": {
             "hashes": [
-                "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c",
-                "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"
+                "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+                "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.17.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.18.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:507a5b60953874766d8a366e8e8c7af63e058b26345cfcb5f91f89d987fd6b74",
-                "sha256:6a69beb4a6f63debebaab0a3477ecd0f559aa726af4954fc948c51f7a2549e23"
+                "sha256:32cd6c042b5004b8e857d727708720c54a676d1e22917cf1a2df9b4d4868abd6",
+                "sha256:e9b7171e242dcc6ebd0aaa7540481d1a72860748a0a7816b8fe6cf6c80a6fe7e"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.1.0"
+            "version": "==3.2.5"
         },
         "pyparsing": {
             "hashes": [
@@ -1278,14 +1363,22 @@
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.1.2"
         },
+        "pyproject-hooks": {
+            "hashes": [
+                "sha256:4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965",
+                "sha256:7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.1.0"
+        },
         "pytest": {
             "hashes": [
-                "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7",
-                "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"
+                "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343",
+                "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.1.1"
+            "version": "==8.2.2"
         },
         "pytest-assume": {
             "hashes": [
@@ -1297,12 +1390,12 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6",
-                "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"
+                "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652",
+                "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==4.1.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.0.0"
         },
         "pytest-env": {
             "hashes": [
@@ -1340,12 +1433,12 @@
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f",
-                "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.12.0"
+            "version": "==3.14.0"
         },
         "pytest-pspec": {
             "hashes": [
@@ -1377,7 +1470,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytoolconfig": {
@@ -1473,12 +1566,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -1506,12 +1599,12 @@
         },
         "rope": {
             "hashes": [
-                "sha256:01f06624159e6b2ec9b94412d519e8877a19eeabe392f469c36f7236df05d443",
-                "sha256:93a1bb991fbf0426e8d415102d1c092ccc42e826ce9a42c4d61ce53d7786d9d9"
+                "sha256:51437d2decc8806cd5e9dd1fd9c1306a6d9075ecaf78d191af85fc1dfface880",
+                "sha256:b435a0c0971244fdcd8741676a9fae697ae614c20cc36003678a7782f25c0d6c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "secretstorage": {
             "hashes": [
@@ -1535,7 +1628,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "snowballstemmer": {
@@ -1621,10 +1714,10 @@
         },
         "sphinxcontrib-plantuml": {
             "hashes": [
-                "sha256:97a4f2a26af91db88770ccf8a3b2e03305bcda7ec41a7f969fc8cb27b84a3c44"
+                "sha256:2a1266ca43bddf44640ae44107003df4490de2b3c3154a0d627cfb63e9a169bf"
             ],
             "index": "pypi",
-            "version": "==0.29"
+            "version": "==0.30"
         },
         "sphinxcontrib-qthelp": {
             "hashes": [
@@ -1675,28 +1768,28 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b",
-                "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"
+                "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f",
+                "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.12.4"
+            "version": "==0.12.5"
         },
         "traitlets": {
             "hashes": [
-                "sha256:8cdd83c040dab7d1dee822678e5f5d100b514f7b72b01615b26fc5718916fdf9",
-                "sha256:fcdf85684a772ddeba87db2f398ce00b40ff550d1528c03c14dbf6a02003cd80"
+                "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7",
+                "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.14.2"
+            "version": "==5.14.3"
         },
         "twine": {
             "hashes": [
-                "sha256:89b0cc7d370a4b66421cc6102f269aa910fe0f1861c124f573cf2ddedbc10cf4",
-                "sha256:a262933de0b484c53408f9edae2e7821c1c45a3314ff2df9bdd343aa7ab8edc0"
+                "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+                "sha256:9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==5.0.0"
+            "version": "==5.1.1"
         },
         "typing": {
             "hashes": [
@@ -1708,27 +1801,27 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.10.0"
+            "markers": "python_version < '3.11'",
+            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "urwid": {
             "hashes": [
-                "sha256:374931b3a8a147c33e304fec71c098dd8e8a0960b8fd0d4b66f6f536583a3556",
-                "sha256:df9f5504cc6fb07694392dd5862caf27a998bccde11513c6ea2ef2e0e1008852"
+                "sha256:71b3171cabaa0092902f556768756bd2f2ebb24c0da287ee08f081d235340cb7",
+                "sha256:9ecc57330d88c8d9663ffd7092a681674c03ff794b6330ccfef479af7aa9671b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.6.9"
+            "version": "==2.6.15"
         },
         "urwid-readline": {
             "hashes": [
@@ -1745,19 +1838,19 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc",
-                "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"
+                "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
+                "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.1"
+            "version": "==3.0.3"
         },
         "zipp": {
             "hashes": [
-                "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b",
-                "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
+                "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19",
+                "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.18.1"
+            "version": "==3.19.2"
         }
     }
 }

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 pyspark==3.3.0
-pandas==.1.4.3
+pandas==1.4.3
 sphinxcontrib-plantuml==0.18
 docutils<0.18
 sphinx_rtd_theme

--- a/docs/source/transformer/annotator.rst
+++ b/docs/source/transformer/annotator.rst
@@ -1,0 +1,5 @@
+Annotator (Load and Update Column Comments)
+============================================
+
+.. automodule:: spooq.transformer.annotator
+    :members:

--- a/docs/source/transformer/mapper.rst
+++ b/docs/source/transformer/mapper.rst
@@ -3,8 +3,8 @@ Mapper
 
 Class
 -----
-
-.. autoclass:: spooq.transformer.mapper.Mapper
+.. automodule:: spooq.transformer.mapper
+    :members:
 
 Custom Transformations
 ------------------------------------------------

--- a/docs/source/transformer/overview.rst
+++ b/docs/source/transformer/overview.rst
@@ -6,6 +6,7 @@ Transformers
 
 .. toctree::
 
+    annotator
     exploder
     sieve
     mapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
+[tool.pytest.ini_options]
+addopts = "--pspec --html=tests.html --self-contained-html"
+env = [
+  "D:SPOOQ_ENV = test"
+]
+
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 

--- a/spooq/shared.py
+++ b/spooq/shared.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class EnumMode(Enum):
+    @classmethod
+    def to_string(cls) -> str:
+        return "\n".join([f"- {e.name}: {e.value}" for e in cls])

--- a/spooq/transformer/__init__.py
+++ b/spooq/transformer/__init__.py
@@ -1,10 +1,11 @@
-from .newest_by_group import NewestByGroup
-from .mapper import Mapper
-from .exploder import Exploder
-from .threshold_cleaner import ThresholdCleaner
-from .enum_cleaner import EnumCleaner
-from .null_cleaner import NullCleaner
-from .sieve import Sieve
+from spooq.transformer.newest_by_group import NewestByGroup
+from spooq.transformer.mapper import Mapper
+from spooq.transformer.exploder import Exploder
+from spooq.transformer.threshold_cleaner import ThresholdCleaner
+from spooq.transformer.enum_cleaner import EnumCleaner
+from spooq.transformer.null_cleaner import NullCleaner
+from spooq.transformer.sieve import Sieve
+from spooq.transformer.annotator import Annotator
 
 __all__ = [
     "NewestByGroup",
@@ -13,5 +14,6 @@ __all__ = [
     "ThresholdCleaner",
     "EnumCleaner",
     "Sieve",
-    "NullCleaner"
+    "NullCleaner",
+    "Annotator",
 ]

--- a/spooq/transformer/annotator.py
+++ b/spooq/transformer/annotator.py
@@ -53,7 +53,7 @@ class Annotator(Transformer):
     def __init__(
         self,
         comments_mapping: Union[str, Path, dict] = None,
-        mode=AnnotatorMode.upsert,
+        mode: AnnotatorMode = AnnotatorMode.upsert,
         missing_column_handling: MissingColumnHandling = MissingColumnHandling.raise_error,
         sql_source_table_identifier: str = None,
     ):

--- a/spooq/transformer/annotator.py
+++ b/spooq/transformer/annotator.py
@@ -1,21 +1,21 @@
 import logging
-from enum import Enum
 from pathlib import Path
 from typing import Dict, Union
 
 from pyspark.sql import functions as F, types as T, DataFrame, SparkSession
 
+from spooq.shared import EnumMode
 from spooq.transformer.transformer import Transformer
 
 
-class AnnotatorMode(Enum):
+class AnnotatorMode(EnumMode):
     """Possible values: ['insert', 'upsert']"""
 
     insert = "Only add missing comments. Don't overwrite existing comments"
     upsert = "Insert missing comments. Overwrite existing comments"
 
 
-class MissingColumnHandling(Enum):
+class MissingColumnHandling(EnumMode):
     """Possible values: ['raise_error', 'skip']"""
 
     raise_error = "Raise an error when a comment was defined for a missing column"

--- a/spooq/transformer/annotator.py
+++ b/spooq/transformer/annotator.py
@@ -209,17 +209,17 @@ class Annotator(Transformer):
                 f"Trying to add {len(existing_comments_mapping)} existing comments "
                 f"from {self.sql_source_table_identifier} to provided comments_mapping!"
             )
-            for column, comment in existing_comments_mapping.items():
+            for column, existing_comment in existing_comments_mapping.items():
                 if not column in input_df.columns:
                     self.logger.debug(
-                        f"Skipping to apply comment ('{comment}') fetched from the sql_source_table because "
+                        f"Skipping to apply comment ('{existing_comment}') fetched from the sql_source_table because "
                         f"column: '{column}' was not found in the dataframe."
                     )
                     continue
 
                 if column in self.comments_mapping:
                     self.logger.debug(
-                        f"Comment for column: '{column}' is both defined in the sql_source_table ('{comment}') "
+                        f"Comment for column: '{column}' is both defined in the sql_source_table ('{existing_comment}') "
                         f"and the mapping ('{self.comments_mapping[column]}')."
                     )
                     if self.mode == AnnotatorMode.upsert:
@@ -227,7 +227,7 @@ class Annotator(Transformer):
                         continue
 
                 self.logger.debug("Using comment from sql_source_table.")
-                self.comments_mapping[column] = comment
+                self.comments_mapping[column] = existing_comment
 
             self.logger.info(
                 f"Added {len(set(input_df.columns).intersection(set(existing_comments_mapping)))} "

--- a/spooq/transformer/annotator.py
+++ b/spooq/transformer/annotator.py
@@ -1,0 +1,105 @@
+from enum import Enum
+from pathlib import Path
+from typing import Union
+
+from pyspark.sql import functions as F, types as T, DataFrame, SparkSession
+
+from spooq.transformer.transformer import Transformer
+
+
+AnnotatorMode = Enum("mode", ["insert", "upsert"])
+MissingColumnHandling = Enum("missing_column_handling", ["raise_error", "skip"])
+
+
+class ColumnNotFound(ValueError):
+    pass
+
+
+class CommentNotFound(ValueError):
+    pass
+
+
+def load_comments_from_metastore_table(sql_source_table_identifier: str) -> dict:
+    spark = SparkSession.Builder().getOrCreate()
+    table_description = spark.sql(f"DESCRIBE {sql_source_table_identifier}")
+    return {k: v for k, v in table_description.rdd.map(lambda row: (row.col_name, row.comment)).collect() if v}
+
+
+def update_comment(
+    df: DataFrame,
+    column_name: str,
+    comment: str,
+    annotator_mode: AnnotatorMode = AnnotatorMode.upsert,
+    missing_column_handling: MissingColumnHandling = MissingColumnHandling.raise_error,
+) -> DataFrame:
+    if column_name not in df.columns:
+        if missing_column_handling == MissingColumnHandling.skip:
+            return df
+        else:
+            raise ColumnNotFound(
+                f"Comment <{comment}> cannot be applied to Column <{column_name}> "
+                "because the column was not found in the dataframe:\n"
+                "\n".join(df.columns)
+            )
+
+    existing_comment = df.schema[column_name].metadata.get("comment")
+    if annotator_mode == AnnotatorMode.insert and existing_comment:
+        return df
+
+    return df.withColumn(column_name, F.col(column_name).alias(column_name, metadata={"comment": comment}))
+
+
+class Annotator(Transformer):
+    def __init__(
+        self,
+        comments_mapping: Union[str, Path, dict] = None,
+        mode=AnnotatorMode.upsert,
+        missing_column_handling: MissingColumnHandling = MissingColumnHandling.raise_error,
+        sql_source_table_identifier: str = None,
+    ):
+        super().__init__()
+        self.comments_mapping = comments_mapping or {}
+        self.mode = mode
+        self.missing_column_handling = missing_column_handling
+        self.sql_source_table_identifier = sql_source_table_identifier
+        """
+        # Todo: Put into Docstring
+        if mode not in ["insert", "replace"]:
+            raise ValueError(
+                "Only the following values are allowed for `mode`:\n"
+                "  - replace: new comments are added; existing comments are replaced\n"
+                "  - insert: new comments are added; existing comments are NOT overwritten"
+            )
+        """
+
+    def transform(self, input_df: DataFrame) -> DataFrame:
+        if self.sql_source_table_identifier:
+            self.logger.info(
+                f"sql_source_table_identifier was provided: Trying to load existing comments from source table at <{self.sql_source_table_identifier}> ..."
+            )
+            existing_comments_mapping = load_comments_from_metastore_table(
+                sql_source_table_identifier=self.sql_source_table_identifier
+            )
+            self.logger.info(
+                f"Trying to apply {len(existing_comments_mapping)} existing comments from {self.sql_source_table_identifier} to dataframe!"
+            )
+            input_df = Annotator(
+                comments_mapping=existing_comments_mapping,
+                mode=AnnotatorMode.insert,
+                missing_column_handling=MissingColumnHandling.skip,
+                sql_source_table_identifier=None,
+            ).transform(input_df)
+            self.logger.info(
+                f"Re-applied {len(set(input_df.columns).intersection(set(existing_comments_mapping)))} comments from {self.sql_source_table_identifier}!"
+            )
+
+        self.logger.info(f"Applying {len(self.comments_mapping)} comments from mapping to DataFrame ...")
+        for column, comment in self.comments_mapping.items():
+            input_df = update_comment(
+                df=input_df,
+                column_name=column,
+                comment=comment,
+                annotator_mode=self.mode,
+                missing_column_handling=self.missing_column_handling,
+            )
+        return input_df

--- a/spooq/transformer/mapper.py
+++ b/spooq/transformer/mapper.py
@@ -24,7 +24,7 @@ class MapperMode(Enum):
     replace = "output schema = columns from mapping"
     append = "output schema = input columns + columns from mapping"
     prepend = "output schema = columns from mapping + input columns"
-    rename_and_validate = "output schema = columns from mapping"
+    rename_and_validate = "output schema = columns from mapping + validation"
 
 
 class MissingColumnHandling(Enum):

--- a/spooq/transformer/mapper.py
+++ b/spooq/transformer/mapper.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from functools import partial
 from types import FunctionType
 from typing import Union, List, Tuple, Any, Callable
@@ -11,17 +12,28 @@ from pyspark.sql import (
     Column,
 )
 
-from .transformer import Transformer
-from .mapper_custom_data_types import _get_select_expression_for_custom_type
-from .mapper_transformations import as_is
+from spooq.transformer.annotator import Annotator
+
+from spooq.transformer.transformer import Transformer
+from spooq.transformer.mapper_custom_data_types import _get_select_expression_for_custom_type
+from spooq.transformer.mapper_transformations import as_is
+
 
 class DataTypeValidationFailed(ValueError):
     pass
 
 
+class ColumnMappingNotSupported(ValueError):
+    pass
+
+
+MapperMode = Enum("mapper_mode", ["replace", "append", "prepend", "rename_and_validate"])
+MissingColumnHandling = Enum("missing_column_handling", ["raise_error", "skip", "nullify"])
+
+
 class Mapper(Transformer):
     """
-    Selects, transforms and casts or validates a DataFrame based on the provided mapping.
+    Selects, transforms, comments and casts a DataFrame based on the provided mapping.
 
     Examples
     --------
@@ -29,10 +41,13 @@ class Mapper(Transformer):
     >>> from spooq.transformer import Mapper
     >>> from spooq.transformer import mapper_transformations as spq
     >>>
+    >>> cmt_id = "Identifier for entity (UUID4)"
+    >>> cmt_type = "Type of entity ('type_a', 'type_b' or 'type_c')"
+    >>>
     >>> mapping = [
-    >>>     ("id",            "data.relationships.food.data.id",  spq.to_str),
+    >>>     ("id",            "data.relationships.food.data.id",  spq.to_str,                     cmt_id),
     >>>     ("version",       "data.version",                     spq.to_int),
-    >>>     ("type",          "elem.attributes.type",             "string"),
+    >>>     ("type",          "elem.attributes.type",             "string",                       cmt_type),
     >>>     ("created_at",    "elem.attributes.created_at",       spq.to_timestamp),
     >>>     ("created_on",    "elem.attributes.created_at",       spq.to_timestamp(cast="date")),
     >>>     ("processed_at",  F.current_timestamp(),              spq.as_is,
@@ -49,12 +64,13 @@ class Mapper(Transformer):
 
     Parameters
     ----------
-    mapping  : :class:`list` of :any:`tuple` containing three elements, respectively.
+    mapping  : :class:`list` of :any:`tuple` containing three or four elements, respectively.
         This is the main parameter for this transformation. It gives information
         about the column names for the output DataFrame, the column names (paths)
-        from the input DataFrame, and their data types. Custom data types are also supported, which can
-        clean, pivot, anonymize, ... the data itself. Please have a look at the
-        :py:mod:`spooq.transformer.mapper_custom_data_types` module for more information.
+        from the input DataFrame, their data types and optionally a column comment.
+        Custom data types are also supported, which can clean, pivot, anonymize, ...
+        the data itself. Please have a look at the
+        :py:mod:`spooq.transformer.mapper_transformations` module for more information.
 
     missing_column_handling : :any:`str`, Defaults to 'raise_error'
         Specifies how to proceed in case a source column does not exist in the source DataFrame:
@@ -70,27 +86,30 @@ class Mapper(Transformer):
         raise an exception with Spark when reading. This flag surpresses this exception and skips those affected
         columns.
 
-    mode : :any:`str`, Defaults to "replace"
-        Defines the operation mode of the mapping transformation.
+    mode : :any:`spooq.transformer.mapper.MapperMode` | :any:`str`, Defaults to MapperMode.replace
+        Defines weather the mapping should fully replace the schema of the input DataFrame or just add to it.
         Following modes are supported:
 
             * replace
                 The output schema is the same as the provided mapping.
-                => output schema: columns from mapping
+                => output schema: new columns
             * append
                 The columns provided in the mapping are added at the end of the input schema. If a column already
                 exists in the input DataFrame, its position is kept.
-                => output schema: input columns + columns from mapping
+                => output schema: input columns + new columns
             * prepend
                 The columns provided in the mapping are added at the beginning of the input schema. If a column already
                 exists in the input DataFrame, its position is kept.
-                => output schema: columns from mapping + input columns
+                => output schema: new columns + input columns
             * rename_and_validate
                 All built-in, custom transformations (except renaming) and casts are disabled. The Mapper only
                 renames the columns and validates that the output data type is the same as the input data type. The
                 transformation will fail if any spooq / custom transformations (except `as_is`) are defined!
                 => output schema: columns from mapping
 
+    annotator_option : :any:`dict`, Defaults to {}
+        Options that are passed as parameters to the Annotator instance used by the Mapper
+        Transformer if comments are provided.
 
     Keyword Arguments
     -----------------
@@ -118,6 +137,8 @@ class Mapper(Transformer):
         simple strings supported by PySpark (like "string") and custom transformations provided by spooq
         (like spq.to_timestamp). You can find more information about the transformations at
         https://spooq.rtfd.io/en/latest/transformer/mapper.html#module-spooq.transformer.mapper_transformations.
+    * Comment: :any:`str` (optional)
+        Applies a comment to the respective column, if provided.
 
     Note
     ----
@@ -129,73 +150,110 @@ class Mapper(Transformer):
 
     def __init__(
         self,
-        mapping: List[Tuple[Any, Any, Any]],
+        mapping: List[Tuple],
         ignore_ambiguous_columns: bool = False,
-        missing_column_handling: str = "raise_error",
-        mode: str = "replace",
-        **kwargs
+        missing_column_handling: Union[MissingColumnHandling, str] = MissingColumnHandling.raise_error,
+        mode: Union[MapperMode, str] = MapperMode.replace,
+        annotator_options: dict = None,
+        **kwargs,
     ):
         super(Mapper, self).__init__()
         self.mapping = mapping
         self.missing_column_handling = missing_column_handling
         self.ignore_ambiguous_columns = ignore_ambiguous_columns
         self.mode = mode
+        self.annotator_options = annotator_options or {}
 
-        if self.mode not in ["replace", "append", "prepend", "rename_and_validate"]:
-            raise ValueError(f"""Value: '{mode}' was used as mode for the Mapper transformer.
-                Only the following values are allowed for `mode`:
-                - replace: The output schema is the same as the provided mapping.
-                - append: The columns provided in the mapping are added at the end of the input schema.
-                - prepend: The columns provided in the mapping are added at the beginning of the input schema.
-                - rename_and_validate: The Mapper only renames the columns and validates that the output data
-                  type is the same as the input data type.
-            """)
+        if isinstance(self.mode, str):
+            message = f"'mode' as string is deprecated, please provide the mode as a MapperMode object!"
+            self.logger.warning(message)
+            warnings.warn(message=message, category=FutureWarning)
+            try:
+                self.mode = MapperMode[self.mode]
+            except KeyError:
+                raise ValueError(
+                    f"""Value: '{self.mode}' was used as mode for the Mapper transformer.
+                    Only the following values are allowed for `mode`:
+                    - replace: The output schema is the same as the provided mapping.
+                    - append: The columns provided in the mapping are added at the end of the input schema.
+                    - prepend: The columns provided in the mapping are added at the beginning of the input schema.
+                    - rename_and_validate: The Mapper only renames the columns and validates that the output data
+                      type is the same as the input data type.
+                """
+                )
+
+        if isinstance(self.missing_column_handling, str):
+            message = (
+                "'missing_column_handling' as string is deprecated, "
+                "please provide the parameter as a MissingColumnHandling object!"
+            )
+            self.logger.warning(message)
+            warnings.warn(message=message, category=FutureWarning)
+            try:
+                self.missing_column_handling = MissingColumnHandling[self.missing_column_handling]
+            except KeyError:
+                raise ValueError(
+                    """Only the following values are allowed for `missing_column_handling`:
+                    - raise_error: raise an exception in case the source column is missing
+                    - skip: skip transformation in case the source is missing
+                    - nullify: set source column to null in case it is missing"""
+                )
 
         if "ignore_missing_columns" in kwargs:
             message = "Parameter `ignore_missing_columns` is deprecated, use `missing_column_handling` instead!"
             if kwargs["ignore_missing_columns"]:
-                message += "\n`missing_column_handling` was set to `nullify` because you defined " \
-                           "`ignore_missing_columns=True`!"
-                self.missing_column_handling = "nullify"
+                message += (
+                    "\n`missing_column_handling` was set to `nullify` because you defined "
+                    "`ignore_missing_columns=True`!"
+                )
+                self.missing_column_handling = MissingColumnHandling.nullify
             self.logger.warning(message)
             warnings.warn(message=message, category=FutureWarning)
-
-        if self.missing_column_handling not in ["raise_error", "skip", "nullify"]:
-            raise ValueError("""Only the following values are allowed for `missing_column_handling`:
-                - raise_error: raise an exception in case the source column is missing
-                - skip: skip transformation in case the source is missing
-                - nullify: set source column to null in case it is missing""")
 
     def transform(self, input_df: DataFrame) -> DataFrame:
         self.logger.info("Generating SQL Select-Expression for Mapping...")
         self.logger.debug("Input Schema/Mapping:")
         self.logger.debug("\n" + "\n".join(["\t".join(map(str, mapping_line)) for mapping_line in self.mapping]))
 
+        if not self.mapping:
+            raise ColumnMappingNotSupported("It seems like the provided mapping is empty!")
+
         input_columns = input_df.columns
         select_expressions = []
         with_column_expressions = []
         validation_errors = []
+        comments_mapping = {}
 
-        for (name, source_column, data_transformation) in self.mapping:
+        for column_mapping in self.mapping:
+            if len(column_mapping) == 3:
+                name, source_column, data_transformation, comment = *column_mapping, None
+            elif len(column_mapping) == 4:
+                name, source_column, data_transformation, comment = column_mapping
+            else:
+                raise ColumnMappingNotSupported(
+                    "Each mapping tuple (column) must contain at least 3 and at most 4 elements!\n"
+                    f"Following mapping contains {len(column_mapping)} elements: {column_mapping}"
+                )
             self.logger.debug(f"generating Select statement for attribute: {name}")
             self.logger.debug(
                 f"generate mapping for name: {name}, "
                 f"source_column: {source_column}, "
                 f"data_transformation: {data_transformation}"
+                f"comment: {comment}"
             )
+
             source_column: Column = self._get_source_spark_column(source_column, name, input_df)
             if source_column is None:
-                if self.mode == "rename_and_validate":
+                if self.mode == MapperMode.rename_and_validate:
                     validation_errors.append(DataTypeValidationFailed(f"Input column: {name} not found!"))
                 continue
 
             source_spark_data_type: T.DataType = self._get_spark_data_type(input_df.select(source_column).dtypes[0][1])
-            target_transformation: Union[T.DataType, Column] = (
-                self._get_spark_data_type(data_transformation)
-                or self._get_spooq_transformation(name, source_column, data_transformation)
-            )
+            target_transformation: Union[T.DataType, Column] = self._get_spark_data_type(
+                data_transformation
+            ) or self._get_spooq_transformation(name, source_column, data_transformation)
 
-            if self.mode == "rename_and_validate":
+            if self.mode == MapperMode.rename_and_validate:
                 try:
                     self._validate_data_type(
                         name,
@@ -216,10 +274,13 @@ class Mapper(Transformer):
                 select_expression = target_transformation
 
             self.logger.debug(f"Select-Expression for Attribute {name}: {select_expression}")
-            if self.mode in ["append", "prepend"] and name in input_columns:
+            if self.mode.name in ["append", "prepend"] and name in input_columns:
                 with_column_expressions.append((name, select_expression))
             else:
                 select_expressions.append(select_expression)
+
+            if comment:
+                comments_mapping[name] = comment
 
         if validation_errors:
             raise DataTypeValidationFailed(f"Validation has failed!\n{validation_errors}")
@@ -227,9 +288,10 @@ class Mapper(Transformer):
         self.logger.info("SQL Select-Expression for new mapping generated!")
         self.logger.debug("SQL Select-Expressions for new mapping:\n" + "\n".join(str(select_expressions).split(",")))
         self.logger.debug("SQL WithColumn-Expressions for new mapping: " + str(with_column_expressions))
-        if self.mode == "prepend":
+
+        if self.mode == MapperMode.prepend:
             df_to_return = input_df.select(select_expressions + ["*"])
-        elif self.mode == "append":
+        elif self.mode == MapperMode.append:
             df_to_return = input_df.select(["*"] + select_expressions)
         else:
             df_to_return = input_df.select(select_expressions)
@@ -237,6 +299,11 @@ class Mapper(Transformer):
         if with_column_expressions:
             for name, expression in with_column_expressions:
                 df_to_return = df_to_return.withColumn(name, expression)
+
+        if comments_mapping or self.annotator_options.get("sql_source_table_identifier"):
+            annotator = Annotator(comments_mapping=comments_mapping, **self.annotator_options)
+            df_to_return = annotator.transform(df_to_return)
+
         return df_to_return
 
     def _get_source_spark_column(
@@ -252,14 +319,14 @@ class Mapper(Transformer):
                 source_column = F.col(source_column)
 
         except AnalysisException as e:
-            if isinstance(source_column, str) and self.missing_column_handling == "skip":
+            if isinstance(source_column, str) and self.missing_column_handling == MissingColumnHandling.skip:
                 self.logger.warning(
-                    f"Missing column ({str(source_column)}) skipped (via missing_column_handling='skip'): {e.desc}"
+                    f"Missing column ({str(source_column)}) skipped (MissingColumnHandling.skip): {e.desc}"
                 )
                 return None
-            elif isinstance(source_column, str) and self.missing_column_handling == "nullify":
+            elif isinstance(source_column, str) and self.missing_column_handling == MissingColumnHandling.nullify:
                 self.logger.warning(
-                    f"Missing column ({str(source_column)}) replaced with NULL (via missing_column_handling='nullify'): {e.desc}"
+                    f"Missing column ({str(source_column)}) replaced with NULL (via MissingColumnHandling.nullify): {e.desc}"
                 )
                 source_column = F.lit(None)
             elif "ambiguous" in e.desc.lower() and self.ignore_ambiguous_columns:
@@ -268,18 +335,18 @@ class Mapper(Transformer):
                 )
                 return None
             else:
-                self.logger.exception(f"""
+                self.logger.exception(
+                    f"""
                 Column: '{source_column}' cannot be resolved but is referenced in the mapping by column: '{name}'.
                 You can make use of the following parameters to handle missing input columns:
-                - missing_column_handling='nullify': set missing source column to null
-                - missing_column_handling='skip': skip the transformation
-                """)
+                - MissingColumnHandling.nullify: set missing source column to null
+                - MissingColumnHandling.skip: skip the transformation
+                """
+                )
                 raise e
         return source_column
 
-    def _get_spark_data_type(
-        self, data_transformation: Union[str, Column, Callable, T.DataType]
-    ) -> T.DataType:
+    def _get_spark_data_type(self, data_transformation: Union[str, Column, Callable, T.DataType]) -> T.DataType:
         """
         Returns the PySpark data type as Python object (None if not found). Supports Python objects and strings.
         """
@@ -294,7 +361,9 @@ class Mapper(Transformer):
                 data_type = getattr(T, data_type_)()  # Spark datatype as string
             except AttributeError:
                 try:
-                    data_type = T._parse_datatype_string("void" if data_type_ == "null" else data_type_)  # Spark datatype as short string
+                    data_type = T._parse_datatype_string(
+                        "void" if data_type_ == "null" else data_type_
+                    )  # Spark datatype as short string
                 except ParseException:
                     pass
 
@@ -313,8 +382,7 @@ class Mapper(Transformer):
         if isinstance(target_transformation, T.DataType):
             if isinstance(source_spark_data_type, T.NullType):
                 self.logger.warning(
-                    f"The data type of column {name} could not be validated because the source "
-                    "data type is NULL!"
+                    f"The data type of column {name} could not be validated because the source " "data type is NULL!"
                 )
             elif target_transformation != source_spark_data_type:
                 raise DataTypeValidationFailed(

--- a/spooq/transformer/mapper.py
+++ b/spooq/transformer/mapper.py
@@ -13,7 +13,6 @@ from pyspark.sql import (
 )
 
 from spooq.transformer.annotator import Annotator
-
 from spooq.transformer.transformer import Transformer
 from spooq.transformer.mapper_custom_data_types import _get_select_expression_for_custom_type
 from spooq.transformer.mapper_transformations import as_is
@@ -33,7 +32,7 @@ MissingColumnHandling = Enum("missing_column_handling", ["raise_error", "skip", 
 
 class Mapper(Transformer):
     """
-    Selects, transforms, comments and casts a DataFrame based on the provided mapping.
+    Selects, transforms, comments and casts or validates a DataFrame based on the provided mapping.
 
     Examples
     --------
@@ -87,7 +86,7 @@ class Mapper(Transformer):
         columns.
 
     mode : :any:`spooq.transformer.mapper.MapperMode` | :any:`str`, Defaults to MapperMode.replace
-        Defines weather the mapping should fully replace the schema of the input DataFrame or just add to it.
+        Defines whether the mapping should fully replace the schema of the input DataFrame or just add to it.
         Following modes are supported:
 
             * replace

--- a/spooq/transformer/mapper.py
+++ b/spooq/transformer/mapper.py
@@ -26,6 +26,10 @@ class MapperMode(Enum):
     prepend = "output schema = columns from mapping + input columns"
     rename_and_validate = "output schema = columns from mapping + validation"
 
+    @classmethod
+    def to_string(cls) -> str:
+        return "\n".join([f"- {e.name}: {e.value}" for e in cls])
+
 
 class MissingColumnHandling(Enum):
     """Possible values: ['raise_error', 'skip', 'nullify']"""
@@ -394,7 +398,7 @@ class Mapper(Transformer):
         if isinstance(target_transformation, T.DataType):
             if isinstance(source_spark_data_type, T.NullType):
                 self.logger.warning(
-                    f"The data type of column {name} could not be validated because the source " "data type is NULL!"
+                    f"The data type of column {name} could not be validated because the source data type is NULL!"
                 )
             elif target_transformation != source_spark_data_type:
                 raise DataTypeValidationFailed(

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-addopts = --pspec --html=tests.html --self-contained-html
-# pspec_format = plaintext
-env =
-    D:SPOOQ_ENV=test  # effects ERROR log level
-    ; D:SPOOQ_ENV=dev  # effects DEBUG log level
-
-[coverage:report]
-skip_empty = true

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -11,6 +11,12 @@ from spooq.transformer import Annotator
 from spooq.transformer.annotator import update_comment, ColumnNotFound, CommentNotFound, AnnotatorMode
 
 
+def test_debug(spark_session):
+    import IPython
+
+    IPython.embed()
+
+
 @pytest.fixture(scope="module")
 def setup_database(spark_session: SparkSession):
     spark_session.sql("CREATE DATABASE IF NOT EXISTS db")

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -8,13 +8,7 @@ from chispa.dataframe_comparer import assert_df_equality
 
 from tests import DATA_FOLDER
 from spooq.transformer import Annotator
-from spooq.transformer.annotator import update_comment, ColumnNotFound, CommentNotFound, AnnotatorMode
-
-
-def test_debug(spark_session):
-    import IPython
-
-    IPython.embed()
+from spooq.transformer.annotator import update_comment, ColumnNotFound, AnnotatorMode
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -38,7 +38,9 @@ def table_without_comments(spark_session: SparkSession, input_df_without_comment
 
 @pytest.fixture()
 def table_with_partial_comments(spark_session: SparkSession, input_df_with_partial_comments: DataFrame):
-    input_df_with_partial_comments.write.saveAsTable(name="table_with_partial_comments", format="delta", mode="overwrite")
+    input_df_with_partial_comments.write.saveAsTable(
+        name="table_with_partial_comments", format="delta", mode="overwrite"
+    )
     yield "table_with_partial_comments"
     spark_session.sql("DROP TABLE table_with_partial_comments")
 
@@ -61,16 +63,22 @@ class TestUpdateCommentsMethod:
         return input_df_with_partial_comments
 
     def test_add_non_existing_comment(self, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_b", comment="added", annotator_mode=AnnotatorMode.insert)
+        output_df = update_comment(
+            df=input_df, column_name="col_b", comment="added", annotator_mode=AnnotatorMode.insert
+        )
         assert output_df.schema["col_b"].metadata.get("comment") == "added"
 
     def test_add_existing_comment_does_not_overwrite(self, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_a", comment="added", annotator_mode=AnnotatorMode.insert)
+        output_df = update_comment(
+            df=input_df, column_name="col_a", comment="added", annotator_mode=AnnotatorMode.insert
+        )
         assert output_df.schema["col_a"].metadata.get("comment") == "initial"
 
     @pytest.mark.parametrize("comment", ["", "     ", None])
     def test_add_empty_comment(self, comment: str, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.insert)
+        output_df = update_comment(
+            df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.insert
+        )
         assert output_df.schema["col_b"].metadata.get("comment") == comment
 
     def test_add_comment_for_missing_column_raises_exception(self, input_df: DataFrame):
@@ -78,33 +86,36 @@ class TestUpdateCommentsMethod:
             update_comment(df=input_df, column_name="col_c", comment="added", annotator_mode=AnnotatorMode.insert)
 
     def test_replace_non_existing_comment(self, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_b", comment="replaced", annotator_mode=AnnotatorMode.upsert)
+        output_df = update_comment(
+            df=input_df, column_name="col_b", comment="replaced", annotator_mode=AnnotatorMode.upsert
+        )
         assert output_df.schema["col_b"].metadata.get("comment") == "replaced"
 
     def test_replace_existing_comment(self, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_a", comment="replaced", annotator_mode=AnnotatorMode.upsert)
+        output_df = update_comment(
+            df=input_df, column_name="col_a", comment="replaced", annotator_mode=AnnotatorMode.upsert
+        )
         assert output_df.schema["col_a"].metadata.get("comment") == "replaced"
 
     @pytest.mark.parametrize("comment", ["", "     ", None])
     def test_replace_with_empty_comment(self, comment: str, input_df: DataFrame):
-        output_df = update_comment(df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.upsert)
+        output_df = update_comment(
+            df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.upsert
+        )
         assert output_df.schema["col_b"].metadata.get("comment") == comment
 
 
 class TestAnnotatorTransformer:
     @pytest.fixture(scope="class")
     def comments_mapping(self, input_df_without_comments: DataFrame) -> List[Dict]:
-        return {
-            col_name: "updated"
-            for col_name in input_df_without_comments.columns
-        }
+        return {col_name: "updated" for col_name in input_df_without_comments.columns}
 
     @pytest.mark.parametrize(
         argnames=["column_name", "expected_comment"],
         argvalues=[
             ("col_a", "updated"),
             ("col_b", "updated"),
-        ]
+        ],
     )
     def test_adding_comments_to_non_commmented_table(
         self,
@@ -113,18 +124,23 @@ class TestAnnotatorTransformer:
         spark_session: SparkSession,
         comments_mapping: List[Dict],
         input_df_without_comments: DataFrame,
-        table_without_comments: str
+        table_without_comments: str,
     ):
-        Annotator(comments_mapping).transform(input_df_without_comments).write.saveAsTable(table_without_comments, mode="overwrite")
+        Annotator(comments_mapping).transform(input_df_without_comments).write.saveAsTable(
+            table_without_comments, mode="overwrite"
+        )
         table_description_df = spark_session.sql(f"DESCRIBE {table_without_comments}")
-        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+        assert (
+            table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0]
+            == expected_comment
+        )
 
     @pytest.mark.parametrize(
         argnames=["column_name", "expected_comment"],
         argvalues=[
             ("col_a", "updated"),
             ("col_b", "updated"),
-        ]
+        ],
     )
     def test_add_or_replace_comments_to_partially_commmented_table(
         self,
@@ -133,18 +149,23 @@ class TestAnnotatorTransformer:
         spark_session: SparkSession,
         comments_mapping: List[Dict],
         input_df_without_comments: DataFrame,
-        table_with_partial_comments: str
+        table_with_partial_comments: str,
     ):
-        Annotator(comments_mapping, mode=AnnotatorMode.upsert, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        Annotator(
+            comments_mapping, mode=AnnotatorMode.upsert, sql_source_table_identifier=table_with_partial_comments
+        ).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
         table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
-        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+        assert (
+            table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0]
+            == expected_comment
+        )
 
     @pytest.mark.parametrize(
         argnames=["column_name", "expected_comment"],
         argvalues=[
             ("col_a", "initial"),
             ("col_b", "updated"),
-        ]
+        ],
     )
     def test_add_comments_to_partially_commmented_table(
         self,
@@ -153,18 +174,23 @@ class TestAnnotatorTransformer:
         spark_session: SparkSession,
         comments_mapping: List[Dict],
         input_df_without_comments: DataFrame,
-        table_with_partial_comments: str
+        table_with_partial_comments: str,
     ):
-        Annotator(comments_mapping, mode=AnnotatorMode.insert, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        Annotator(
+            comments_mapping, mode=AnnotatorMode.insert, sql_source_table_identifier=table_with_partial_comments
+        ).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
         table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
-        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+        assert (
+            table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0]
+            == expected_comment
+        )
 
     @pytest.mark.parametrize(
         argnames=["column_name", "expected_comment"],
         argvalues=[
             ("col_a", "initial"),
             ("col_b", None),
-        ]
+        ],
     )
     def test_only_fetch_comments_from_partially_commmented_table(
         self,
@@ -172,8 +198,13 @@ class TestAnnotatorTransformer:
         expected_comment: str,
         spark_session: SparkSession,
         input_df_without_comments: DataFrame,
-        table_with_partial_comments: str
+        table_with_partial_comments: str,
     ):
-        Annotator(comments_mapping=None, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        Annotator(comments_mapping=None, sql_source_table_identifier=table_with_partial_comments).transform(
+            input_df_without_comments
+        ).write.saveAsTable(table_with_partial_comments, mode="overwrite")
         table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
-        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+        assert (
+            table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0]
+            == expected_comment
+        )

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -1,0 +1,179 @@
+from typing import List, Dict
+import pytest
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+from pyspark.sql import SparkSession, Row, DataFrame
+from pyspark.sql.utils import AnalysisException
+from chispa.dataframe_comparer import assert_df_equality
+
+from tests import DATA_FOLDER
+from spooq.transformer import Annotator
+from spooq.transformer.annotator import update_comment, ColumnNotFound, CommentNotFound, AnnotatorMode
+
+
+@pytest.fixture(scope="module")
+def input_data():
+    return [
+        Row(col_a=1, col_b=2),
+        Row(col_a=4, col_b=5),
+    ]
+
+
+@pytest.fixture(scope="module")
+def input_df_without_comments(input_data: List[Row], spark_session: SparkSession):
+    return spark_session.createDataFrame(input_data, schema="col_a int, col_b int")
+
+
+@pytest.fixture(scope="module")
+def input_df_with_partial_comments(input_data: List[Row], spark_session: SparkSession):
+    return spark_session.createDataFrame(input_data, schema="col_a int COMMENT 'initial', col_b int")
+
+
+@pytest.fixture()
+def table_without_comments(spark_session: SparkSession, input_df_without_comments: DataFrame):
+    input_df_without_comments.write.saveAsTable(name="table_without_comments", format="delta", mode="overwrite")
+    yield "table_without_comments"
+    spark_session.sql("DROP TABLE table_without_comments")
+
+
+@pytest.fixture()
+def table_with_partial_comments(spark_session: SparkSession, input_df_with_partial_comments: DataFrame):
+    input_df_with_partial_comments.write.saveAsTable(name="table_with_partial_comments", format="delta", mode="overwrite")
+    yield "table_with_partial_comments"
+    spark_session.sql("DROP TABLE table_with_partial_comments")
+
+
+# @pytest.fixture(scope="module")
+# def input_df_with_comments(input_data: List[Row], spark_session: SparkSession):
+#     return spark_session.createDataFrame(
+#         input_data,
+#         schema="""
+#               col_a int COMMENT 'initial'
+#             , col_b int COMMENT 'initial'
+#         """
+#     )
+
+
+class TestUpdateCommentsMethod:
+
+    @pytest.fixture(scope="class")
+    def input_df(self, input_df_with_partial_comments) -> DataFrame:
+        return input_df_with_partial_comments
+
+    def test_add_non_existing_comment(self, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_b", comment="added", annotator_mode=AnnotatorMode.insert)
+        assert output_df.schema["col_b"].metadata.get("comment") == "added"
+
+    def test_add_existing_comment_does_not_overwrite(self, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_a", comment="added", annotator_mode=AnnotatorMode.insert)
+        assert output_df.schema["col_a"].metadata.get("comment") == "initial"
+
+    @pytest.mark.parametrize("comment", ["", "     ", None])
+    def test_add_empty_comment(self, comment: str, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.insert)
+        assert output_df.schema["col_b"].metadata.get("comment") == comment
+
+    def test_add_comment_for_missing_column_raises_exception(self, input_df: DataFrame):
+        with pytest.raises(ColumnNotFound):
+            update_comment(df=input_df, column_name="col_c", comment="added", annotator_mode=AnnotatorMode.insert)
+
+    def test_replace_non_existing_comment(self, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_b", comment="replaced", annotator_mode=AnnotatorMode.upsert)
+        assert output_df.schema["col_b"].metadata.get("comment") == "replaced"
+
+    def test_replace_existing_comment(self, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_a", comment="replaced", annotator_mode=AnnotatorMode.upsert)
+        assert output_df.schema["col_a"].metadata.get("comment") == "replaced"
+
+    @pytest.mark.parametrize("comment", ["", "     ", None])
+    def test_replace_with_empty_comment(self, comment: str, input_df: DataFrame):
+        output_df = update_comment(df=input_df, column_name="col_b", comment=comment, annotator_mode=AnnotatorMode.upsert)
+        assert output_df.schema["col_b"].metadata.get("comment") == comment
+
+
+class TestAnnotatorTransformer:
+    @pytest.fixture(scope="class")
+    def comments_mapping(self, input_df_without_comments: DataFrame) -> List[Dict]:
+        return {
+            col_name: "updated"
+            for col_name in input_df_without_comments.columns
+        }
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "updated"),
+            ("col_b", "updated"),
+        ]
+    )
+    def test_adding_comments_to_non_commmented_table(
+        self,
+        column_name: str,
+        expected_comment: str,
+        spark_session: SparkSession,
+        comments_mapping: List[Dict],
+        input_df_without_comments: DataFrame,
+        table_without_comments: str
+    ):
+        Annotator(comments_mapping).transform(input_df_without_comments).write.saveAsTable(table_without_comments, mode="overwrite")
+        table_description_df = spark_session.sql(f"DESCRIBE {table_without_comments}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "updated"),
+            ("col_b", "updated"),
+        ]
+    )
+    def test_add_or_replace_comments_to_partially_commmented_table(
+        self,
+        column_name: str,
+        expected_comment: str,
+        spark_session: SparkSession,
+        comments_mapping: List[Dict],
+        input_df_without_comments: DataFrame,
+        table_with_partial_comments: str
+    ):
+        Annotator(comments_mapping, mode=AnnotatorMode.upsert, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "initial"),
+            ("col_b", "updated"),
+        ]
+    )
+    def test_add_comments_to_partially_commmented_table(
+        self,
+        column_name: str,
+        expected_comment: str,
+        spark_session: SparkSession,
+        comments_mapping: List[Dict],
+        input_df_without_comments: DataFrame,
+        table_with_partial_comments: str
+    ):
+        Annotator(comments_mapping, mode=AnnotatorMode.insert, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "initial"),
+            ("col_b", None),
+        ]
+    )
+    def test_only_fetch_comments_from_partially_commmented_table(
+        self,
+        column_name: str,
+        expected_comment: str,
+        spark_session: SparkSession,
+        input_df_without_comments: DataFrame,
+        table_with_partial_comments: str
+    ):
+        Annotator(comments_mapping=None, sql_source_table_identifier=table_with_partial_comments).transform(input_df_without_comments).write.saveAsTable(table_with_partial_comments, mode="overwrite")
+        table_description_df = spark_session.sql(f"DESCRIBE {table_with_partial_comments}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -12,6 +12,13 @@ from spooq.transformer.annotator import update_comment, ColumnNotFound, CommentN
 
 
 @pytest.fixture(scope="module")
+def setup_database(spark_session: SparkSession):
+    spark_session.sql("CREATE DATABASE IF NOT EXISTS db")
+    yield
+    spark_session.sql("DROP DATABASE IF EXISTS db")
+
+
+@pytest.fixture(scope="module")
 def input_data():
     return [
         Row(col_a=1, col_b=2),
@@ -30,19 +37,19 @@ def input_df_with_partial_comments(input_data: List[Row], spark_session: SparkSe
 
 
 @pytest.fixture()
-def table_without_comments(spark_session: SparkSession, input_df_without_comments: DataFrame):
-    input_df_without_comments.write.saveAsTable(name="table_without_comments", format="delta", mode="overwrite")
-    yield "table_without_comments"
-    spark_session.sql("DROP TABLE table_without_comments")
+def table_without_comments(spark_session: SparkSession, input_df_without_comments: DataFrame, setup_database):
+    input_df_without_comments.write.saveAsTable(name="db.table_without_comments", format="delta", mode="overwrite")
+    yield "db.table_without_comments"
+    spark_session.sql("DROP TABLE db.table_without_comments")
 
 
 @pytest.fixture()
-def table_with_partial_comments(spark_session: SparkSession, input_df_with_partial_comments: DataFrame):
+def table_with_partial_comments(spark_session: SparkSession, input_df_with_partial_comments: DataFrame, setup_database):
     input_df_with_partial_comments.write.saveAsTable(
-        name="table_with_partial_comments", format="delta", mode="overwrite"
+        name="db.table_with_partial_comments", format="delta", mode="overwrite"
     )
-    yield "table_with_partial_comments"
-    spark_session.sql("DROP TABLE table_with_partial_comments")
+    yield "db.table_with_partial_comments"
+    spark_session.sql("DROP TABLE db.table_with_partial_comments")
 
 
 # @pytest.fixture(scope="module")

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -15,7 +15,7 @@ from spooq.transformer.annotator import update_comment, ColumnNotFound, CommentN
 def setup_database(spark_session: SparkSession):
     spark_session.sql("CREATE DATABASE IF NOT EXISTS db")
     yield
-    spark_session.sql("DROP DATABASE IF EXISTS db")
+    spark_session.sql("DROP DATABASE IF EXISTS db CASCADE")
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/transformer/test_annotator.py
+++ b/tests/unit/transformer/test_annotator.py
@@ -52,17 +52,6 @@ def table_with_partial_comments(spark_session: SparkSession, input_df_with_parti
     spark_session.sql("DROP TABLE db.table_with_partial_comments")
 
 
-# @pytest.fixture(scope="module")
-# def input_df_with_comments(input_data: List[Row], spark_session: SparkSession):
-#     return spark_session.createDataFrame(
-#         input_data,
-#         schema="""
-#               col_a int COMMENT 'initial'
-#             , col_b int COMMENT 'initial'
-#         """
-#     )
-
-
 class TestUpdateCommentsMethod:
 
     @pytest.fixture(scope="class")
@@ -124,7 +113,7 @@ class TestAnnotatorTransformer:
             ("col_b", "updated"),
         ],
     )
-    def test_adding_comments_to_non_commmented_table(
+    def test_adding_comments_to_non_commented_table(
         self,
         column_name: str,
         expected_comment: str,
@@ -149,7 +138,7 @@ class TestAnnotatorTransformer:
             ("col_b", "updated"),
         ],
     )
-    def test_add_or_replace_comments_to_partially_commmented_table(
+    def test_add_or_replace_comments_to_partially_commented_table(
         self,
         column_name: str,
         expected_comment: str,
@@ -174,7 +163,7 @@ class TestAnnotatorTransformer:
             ("col_b", "updated"),
         ],
     )
-    def test_add_comments_to_partially_commmented_table(
+    def test_add_comments_to_partially_commented_table(
         self,
         column_name: str,
         expected_comment: str,
@@ -199,7 +188,7 @@ class TestAnnotatorTransformer:
             ("col_b", None),
         ],
     )
-    def test_only_fetch_comments_from_partially_commmented_table(
+    def test_only_fetch_comments_from_partially_commented_table(
         self,
         column_name: str,
         expected_comment: str,

--- a/tests/unit/transformer/test_mapper.py
+++ b/tests/unit/transformer/test_mapper.py
@@ -2,23 +2,28 @@ from builtins import str
 from builtins import object
 from typing import List
 from copy import deepcopy
+from uuid import uuid4
 
 import pytest
 from pyspark.sql import functions as F
 from pyspark.sql import types as T
 from pyspark.sql import Row
+from pyspark.sql import DataFrame
+from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 from chispa.dataframe_comparer import assert_df_equality
 
-from spooq.transformer.mapper import DataTypeValidationFailed
+from spooq.transformer.annotator import Annotator, AnnotatorMode
+from spooq.transformer.mapper import ColumnMappingNotSupported, DataTypeValidationFailed, MapperMode
 from tests import DATA_FOLDER
 from spooq.transformer import Mapper
+from spooq.transformer.mapper import MapperMode, MissingColumnHandling
 from spooq.transformer import mapper_transformations as spq
 
 
 @pytest.fixture(scope="module")
 def transformer(mapping):
-    return Mapper(mapping=mapping, missing_column_handling="nullify")
+    return Mapper(mapping=mapping, missing_column_handling=MissingColumnHandling.nullify)
 
 
 @pytest.fixture(scope="module")
@@ -98,6 +103,31 @@ class TestBasicAttributes(object):
         assert str(transformer) == "Transformer Object of Class Mapper"
 
 
+class TestLenghtOfMappingTuple:
+    @pytest.fixture(scope="class")
+    def input_df(self, spark_session: SparkSession):
+        return spark_session.range(0)
+
+    def test_column_mapping_without_comments(self, input_df: DataFrame):
+        mapping = [ ( "id", "id", T.LongType() ) ]
+        output_df = Mapper(mapping).transform(input_df)
+        assert_df_equality(input_df, output_df)
+
+    def test_column_mapping_with_comments(self, input_df: DataFrame):
+        mapping = [ ( "id", "id", T.LongType(), "This column contains the ID" ) ]
+        output_df = Mapper(mapping).transform(input_df)
+        assert_df_equality(input_df, output_df, ignore_metadata=True)
+
+    @pytest.mark.parametrize(
+        "num_of_elements",
+        (0, 1, 2, 5, 6)
+    )
+    def test_unsupported_number_of_elements_for_column_mapping(self, input_df: DataFrame, num_of_elements: int):
+        mapping = ["string" for x in range(0, num_of_elements)]
+        with pytest.raises(ColumnMappingNotSupported):
+            Mapper(mapping).transform(input_df)
+
+
 class TestShapeOfMappedDataFrame(object):
     def test_same_amount_of_records(self, input_df, mapped_df):
         """Amount of Rows is the same after the transformation"""
@@ -142,14 +172,14 @@ class TestMultipleMappings(object):
 
     def test_appending_a_mapping(self, mapped_df, new_mapping, input_columns, new_columns):
         """Output schema is correct for added mapping at the end of the input schema"""
-        new_mapped_df = Mapper(mapping=new_mapping, mode="append", missing_column_handling="nullify").transform(
+        new_mapped_df = Mapper(mapping=new_mapping, mode=MapperMode.append, missing_column_handling=MissingColumnHandling.nullify).transform(
             mapped_df
         )
         assert input_columns + new_columns == new_mapped_df.columns
 
     def test_prepending_a_mapping(self, mapped_df, new_mapping, input_columns, new_columns):
         """Output schema is correct for added mapping at the beginning of the input schema"""
-        new_mapped_df = Mapper(mapping=new_mapping, mode="prepend", missing_column_handling="nullify").transform(
+        new_mapped_df = Mapper(mapping=new_mapping, mode=MapperMode.prepend, missing_column_handling=MissingColumnHandling.nullify).transform(
             mapped_df
         )
         assert new_columns + input_columns == new_mapped_df.columns
@@ -163,7 +193,7 @@ class TestMultipleMappings(object):
         ]
         new_columns = [name for (name, path, data_type) in new_mapping]
         new_columns_deduplicated = [x for x in new_columns if x not in input_columns]
-        new_mapped_df = Mapper(mapping=new_mapping, mode="append", missing_column_handling="nullify").transform(
+        new_mapped_df = Mapper(mapping=new_mapping, mode=MapperMode.append, missing_column_handling=MissingColumnHandling.nullify).transform(
             mapped_df
         )
         assert input_columns + new_columns_deduplicated == new_mapped_df.columns
@@ -179,7 +209,7 @@ class TestMultipleMappings(object):
         ]
         new_columns = [name for (name, path, data_type) in new_mapping]
         new_columns_deduplicated = [x for x in new_columns if x not in input_columns]
-        new_mapped_df = Mapper(mapping=new_mapping, mode="prepend", missing_column_handling="nullify").transform(
+        new_mapped_df = Mapper(mapping=new_mapping, mode=MapperMode.prepend, missing_column_handling=MissingColumnHandling.nullify).transform(
             mapped_df
         )
         assert new_columns_deduplicated + input_columns == new_mapped_df.columns
@@ -194,7 +224,7 @@ class TestExceptionForMissingInputColumns(object):
 
     @pytest.fixture(scope="class")
     def transformer(self, mapping):
-        return Mapper(mapping=mapping, missing_column_handling="raise_error")
+        return Mapper(mapping=mapping, missing_column_handling=MissingColumnHandling.raise_error)
 
     def test_missing_column_raises_exception(self, input_df, transformer):
         input_df = input_df.drop("attributes")
@@ -214,7 +244,7 @@ class TestNullifyMissingColumns(object):
 
     @pytest.fixture(scope="class")
     def transformer(self, mapping):
-        return Mapper(mapping=mapping, missing_column_handling="nullify")
+        return Mapper(mapping=mapping, missing_column_handling=MissingColumnHandling.nullify)
 
     @pytest.fixture(scope="class")
     def mapped_df(self, input_df, transformer):
@@ -241,7 +271,7 @@ class TestSkipMissingColumns(object):
 
     @pytest.fixture(scope="class")
     def transformer(self, mapping):
-        return Mapper(mapping=mapping, missing_column_handling="skip")
+        return Mapper(mapping=mapping, missing_column_handling=MissingColumnHandling.skip)
 
     @pytest.fixture(scope="class")
     def mapped_df(self, input_df, transformer):
@@ -342,7 +372,7 @@ class TestValidateDataTypes:
         assert_df_equality(input_df, transformer.transform(input_df))
 
     def test_matching_mapping_with_validation(self, input_df, matching_mapping):
-        transformer = Mapper(matching_mapping, mode="rename_and_validate")
+        transformer = Mapper(matching_mapping, mode=MapperMode.rename_and_validate)
         assert_df_equality(input_df, transformer.transform(input_df))
 
     def test_mismatching_mapping_with_casting(self, input_df, matching_mapping):
@@ -356,14 +386,14 @@ class TestValidateDataTypes:
     def test_mismatching_mapping_with_validation(self, input_df, matching_mapping):
         mapping_ = deepcopy(matching_mapping)
         mapping_[0] = ("col_a", "col_a", T.StringType())
-        transformer = Mapper(mapping_, mode="rename_and_validate")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate)
         with pytest.raises(DataTypeValidationFailed, match="col_a"):
             transformer.transform(input_df)
 
     def test_spooq_transformation_raises_exception(self, input_df, matching_mapping):
         mapping_ = deepcopy(matching_mapping)
         mapping_[0] = ("col_a", "col_a", spq.to_int)
-        transformer = Mapper(mapping_, mode="rename_and_validate")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate)
         with pytest.raises(
             DataTypeValidationFailed, match="Spooq transformations are not allowed in 'rename_and_validate' mode"
         ):
@@ -373,7 +403,7 @@ class TestValidateDataTypes:
         missing_column = "col_d"
         mapping_ = deepcopy(matching_mapping)
         mapping_.append((missing_column, missing_column, T.StringType()))
-        transformer = Mapper(mapping_, mode="rename_and_validate", missing_column_handling="raise_error")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate, missing_column_handling=MissingColumnHandling.raise_error)
         with pytest.raises(
             AnalysisException,
             match=f"A column or function parameter with name `{missing_column}` cannot be resolved.|"
@@ -387,7 +417,7 @@ class TestValidateDataTypes:
         skipped_column = "col_d"
         mapping_ = deepcopy(matching_mapping)
         mapping_.append((skipped_column, skipped_column, T.StringType()))
-        transformer = Mapper(mapping_, mode="rename_and_validate", missing_column_handling="skip")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate, missing_column_handling=MissingColumnHandling.skip)
         with pytest.raises(DataTypeValidationFailed, match=f"Input column: {skipped_column} not found!"):
             transformer.transform(input_df)
 
@@ -395,17 +425,121 @@ class TestValidateDataTypes:
         column_to_nullify = "col_d"
         mapping_ = deepcopy(matching_mapping)
         mapping_.append((column_to_nullify, column_to_nullify, T.StringType()))
-        mapped_df = Mapper(mapping_, mode="rename_and_validate", missing_column_handling="nullify").transform(input_df)
+        mapped_df = Mapper(mapping_, mode=MapperMode.rename_and_validate, missing_column_handling=MissingColumnHandling.nullify).transform(input_df)
         assert mapped_df.schema[column_to_nullify].jsonValue()["type"] == "string"
 
     def test_spooq_transformation_as_is(self, input_df, matching_mapping):
         mapping_ = deepcopy(matching_mapping)
         mapping_[0] = ("col_a", "col_a", spq.as_is)
-        transformer = Mapper(mapping_, mode="rename_and_validate")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate)
         assert_df_equality(input_df, transformer.transform(input_df))
 
     def test_spooq_transformation_as_is_string(self, input_df, matching_mapping):
         mapping_ = deepcopy(matching_mapping)
         mapping_[0] = ("col_a", "col_a", "as_is")
-        transformer = Mapper(mapping_, mode="rename_and_validate")
+        transformer = Mapper(mapping_, mode=MapperMode.rename_and_validate)
         assert_df_equality(input_df, transformer.transform(input_df))
+
+
+class TestColumnComments:
+    @pytest.fixture(scope="module")
+    def input_schema(self) -> str:
+        return """
+            col_a int COMMENT 'initial',
+            col_b int,
+            col_c int
+        """
+
+    @pytest.fixture(scope="class")
+    def input_df(self, spark_session: SparkSession, input_schema: str) -> DataFrame:
+        return spark_session.createDataFrame([Row(col_a=1, col_b=2, col_c=3)], input_schema)
+
+    @pytest.fixture()
+    def input_table(self, spark_session: SparkSession, input_df: DataFrame) -> str:
+        input_df.write.saveAsTable(name="table_with_partial_comments", format="delta", mode="overwrite")
+        yield "table_with_partial_comments"
+        spark_session.sql("DROP TABLE table_with_partial_comments")
+
+    @pytest.fixture(scope="class")
+    def mapping(self) -> List[tuple]:
+        # fmt: off
+        return [
+            ("col_a", "col_a", spq.as_is, "updated"),
+            ("col_b", "col_b", spq.as_is, "updated"),
+            ("col_c", "col_c", spq.as_is),
+        ]
+        # fmt: on
+
+    @pytest.fixture()
+    def random_string(self) -> str:
+        return str(uuid4())[:8]
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "initial"),  # taken from referenced sql_source_table
+            ("col_b", None),
+            ("col_c", None),
+        ]
+    )
+    def test_fetch_comments_from_input_table(self, spark_session: SparkSession, column_name: str, expected_comment: str, mapping: List, input_table: str, random_string: str):
+        mapping = [
+            ("col_a", "col_a", spq.as_is),
+            ("col_b", "col_b", spq.as_is),
+            ("col_c", "col_c", spq.as_is),
+        ]
+        source_df = spark_session.table(input_table)
+        output_df = Mapper(mapping=mapping, annotator_options={"sql_source_table_identifier": input_table}).transform(source_df)
+        output_df.write.saveAsTable(f"output_table_{random_string}")
+        table_description_df = spark_session.sql(f"DESCRIBE output_table_{random_string}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "initial"),  # taken from referenced sql_source_table
+            ("col_x", None),
+            ("col_y", "updated"),  # taken from mapping
+        ]
+    )
+    def test_fetch_comments_from_related_table(self, spark_session: SparkSession, column_name: str, expected_comment: str, input_table: str, random_string: str):
+        source_df = spark_session.createDataFrame([], "col_a int, col_x int, col_y int")
+        mapping = [
+            ("col_a", "col_a", spq.as_is),
+            ("col_x", "col_x", spq.as_is),
+            ("col_y", "col_y", spq.as_is, "updated"),
+        ]
+        output_df = Mapper(mapping, annotator_options={"sql_source_table_identifier": input_table}).transform(source_df)
+        output_df.write.saveAsTable(f"output_table_{random_string}")
+        table_description_df = spark_session.sql(f"DESCRIBE output_table_{random_string}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "initial"),
+            ("col_b", "updated"),
+            ("col_c", None),
+        ]
+    )
+    def test_insert_comments_to_input_table(self, spark_session: SparkSession, column_name: str, expected_comment: str, mapping: List, input_table: str, random_string: str):
+        source_df = spark_session.table(input_table)
+        output_df = Mapper(mapping, annotator_options={"mode": AnnotatorMode.insert, "sql_source_table_identifier": input_table}).transform(source_df)
+        output_df.write.saveAsTable(f"output_table_{random_string}")
+        table_description_df = spark_session.sql(f"DESCRIBE output_table_{random_string}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment
+
+    @pytest.mark.parametrize(
+        argnames=["column_name", "expected_comment"],
+        argvalues=[
+            ("col_a", "updated"),
+            ("col_b", "updated"),
+            ("col_c", None),
+        ]
+    )
+    def test_upsert_comments_to_input_table(self, spark_session: SparkSession, column_name: str, expected_comment: str, mapping: List, input_table: str, random_string: str):
+        source_df = spark_session.table(input_table)
+        output_df = Mapper(mapping, annotator_options={"mode": AnnotatorMode.upsert}).transform(source_df)
+        output_df.write.saveAsTable(f"output_table_{random_string}")
+        table_description_df = spark_session.sql(f"DESCRIBE output_table_{random_string}")
+        assert table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0] == expected_comment

--- a/tests/unit/transformer/test_mapper.py
+++ b/tests/unit/transformer/test_mapper.py
@@ -451,7 +451,7 @@ class TestColumnComments:
     def setup_database(self, spark_session: SparkSession):
         spark_session.sql("CREATE DATABASE IF NOT EXISTS db")
         yield
-        spark_session.sql("DROP DATABASE IF EXISTS db")
+        spark_session.sql("DROP DATABASE IF EXISTS db CASCADE")
 
     @pytest.fixture(scope="module")
     def input_schema(self) -> str:

--- a/tests/unit/transformer/test_mapper.py
+++ b/tests/unit/transformer/test_mapper.py
@@ -466,7 +466,7 @@ class TestColumnComments:
         return spark_session.createDataFrame([Row(col_a=1, col_b=2, col_c=3)], input_schema)
 
     @pytest.fixture()
-    def input_table(self, spark_session: SparkSession, input_df: DataFrame) -> str:
+    def input_table(self, spark_session: SparkSession, input_df: DataFrame, setup_database) -> str:
         input_df.write.saveAsTable(name="db.table_with_partial_comments", format="delta", mode="overwrite")
         yield "db.table_with_partial_comments"
         spark_session.sql("DROP TABLE db.table_with_partial_comments")

--- a/tests/unit/transformer/test_mapper.py
+++ b/tests/unit/transformer/test_mapper.py
@@ -511,8 +511,8 @@ class TestColumnComments:
         output_df = Mapper(mapping=mapping, annotator_options={"sql_source_table_identifier": input_table}).transform(
             source_df
         )
-        output_df.write.saveAsTable(f"output_table_{random_string}")
-        table_description_df = spark_session.sql(f"DESCRIBE output_table_{random_string}")
+        output_df.write.saveAsTable(f"db.output_table_{random_string}")
+        table_description_df = spark_session.sql(f"DESCRIBE db.output_table_{random_string}")
         assert (
             table_description_df.where(F.col("col_name") == column_name).rdd.map(lambda row: row.comment).collect()[0]
             == expected_comment

--- a/tests/unit/transformer/test_mapper_transformations.py
+++ b/tests/unit/transformer/test_mapper_transformations.py
@@ -27,7 +27,7 @@ def expected_df(request, spark_session, spark_context):
                 request.param[version]
                 for version
                 in request.param.keys()
-                if semver.match(spark_context.version, version)
+                if semver.Version.parse(spark_context.version).match(version)
             )
         except ValueError as e:
             if "match_expr" in str(e):


### PR DESCRIPTION
[ADD] Transformer: "Annotator"
[MOD] Switch from strings to Enums for Mapper options


- Fetch comments from existing table to apply them to a dataframe
- Apply comments to dataframe from explicit mapping
- insert / upsert modes supported

Documentation: https://spooq.readthedocs.io/en/spooq-mapping-has-capability-to-add-comments/transformer/annotator.html 